### PR TITLE
Add SakthiCloud production frontend rebuild (Phase 0 shell + Rooms slice)

### DIFF
--- a/sakthicloud/.gitignore
+++ b/sakthicloud/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.turbo/
+*.tsbuildinfo
+.env
+.env.local

--- a/sakthicloud/.npmrc
+++ b/sakthicloud/.npmrc
@@ -1,0 +1,2 @@
+auto-install-peers=true
+strict-peer-dependencies=false

--- a/sakthicloud/README.md
+++ b/sakthicloud/README.md
@@ -64,11 +64,18 @@ account (see the backend's Implementation Guide) to load live data.
 
 ## Status / next
 
-- **Done:** toolchain + shell, login + auth (real `/auth/login` + 401 refresh),
-  section nav for all 32 modules, entitlement gating, CSS-variable theming,
-  WS client, and the Rooms slice end-to-end.
-- **Next (per the phased plan):** Bookings + Folio (finish Phase 1 money data),
-  then Housekeeping, then F&B/KDS with real-time — each a repeat of the Rooms slice.
-- **Backend:** carries forward unchanged; migrate `apps/api` (JS→TS) in place.
-  The prototype's caveats still hold until each module's tables land
-  (see `backend/MIGRATION-NOTES.md`).
+- **Done — shell:** toolchain, login + auth (real `/auth/login` + 401 refresh),
+  section nav for all 32 modules, entitlement gating, CSS-variable theming, WS client.
+- **Done — Phase 1 money data (front desk):**
+  - **Rooms** — live board, optimistic housekeeping updates, WS refresh.
+  - **Bookings** — list with status filters, check-in modal (real
+    `/bookings/checkin`), check-out (real `/bookings/:id/checkout`); both
+    invalidate the rooms cache so the board stays truthful.
+  - **Folio** — running bill per in-house guest derived from real booking data;
+    incidental lines are session-local until `folio_line`/`folio_payment` land
+    (schema already defined in `packages/shared`).
+- **Next (per the phased plan):** Housekeeping (work orders), then F&B → Kitchen
+  (KDS) with real-time — each a repeat of the Rooms/Bookings slice.
+- **Backend:** carries forward unchanged; migrate `apps/api` (JS→TS) in place and
+  add the folio tables. The prototype's caveats hold until each module's tables
+  land (see `backend/MIGRATION-NOTES.md`).

--- a/sakthicloud/README.md
+++ b/sakthicloud/README.md
@@ -1,0 +1,74 @@
+# SakthiCloud — Production Frontend (SaaS rebuild)
+
+The scalable rebuild of the SakthiCloud frontend, following
+`docs/PRODUCTION-ARCHITECTURE.md`. It replaces the single-file, Babel-in-browser
+prototype with a bundled, code-split, API-backed SPA built for thousands of
+subscriber hotels.
+
+This is **Phase 0 (production-grade shell) + the first API-backed vertical slice
+(Rooms)** — the foundation every other module repeats.
+
+## What's here
+
+```
+sakthicloud/
+├─ apps/
+│  └─ web/                     Vite + React + TS SPA (the hotel-facing app)
+│     └─ src/
+│        ├─ app/               providers, router (code-split, entitlement-gated),
+│        │                     auth context, and the shell (sidebar + topbar)
+│        ├─ lib/               api-client (auth + 401 refresh), query-client,
+│        │                     ws (per-tenant live channel), theme (CSS variables)
+│        ├─ components/        UpgradeGate, Toast
+│        └─ features/
+│           └─ front-desk/rooms/   the reference slice: api → hooks → page → card
+└─ packages/
+   └─ shared/                  the web↔api contract (Zod schemas, entitlements,
+                               nav, roles) — one definition, both sides
+```
+
+## Why this scales (vs. the prototype)
+
+| Prototype | This rebuild |
+|---|---|
+| Babel-in-browser, one 700 KB HTML file | Vite build — bundled, minified, **code-split per module** (a Core tenant never downloads the Finance/Spa chunk) |
+| Module state in `useState`, lost on refresh | **TanStack Query** server state + optimistic updates — persists, and shared across devices/receptionists |
+| No live sync | Per-tenant **WebSocket** channel invalidates queries (live room board, KDS) |
+| Inline-style theme objects | Per-tenant **CSS-variable** theming (`applyTheme`) |
+| Entitlement gating in the HTML only | Shared entitlement map (`@sakthicloud/shared`), identical to backend `config/entitlements.js`; locked-but-visible `UpgradeGate` |
+| Hand-rolled brace/regex checks | **TypeScript + Zod** validated at the trust boundary; `tsc` in the build |
+
+## The six-part migration pattern
+
+Every module is the same recipe, proven by `features/front-desk/rooms/`:
+
+**Prisma model → Zod schema (`packages/shared`) → Fastify route → TanStack Query
+hook → component → WebSocket live sync.**
+
+`RoomsPage` reads `useRooms(propertyId)` (was `useState`), mutates through
+`useUpdateRoom` (optimistic, rolls back on error), and refetches on the
+`room:updated` WS event. Copy this folder per module to migrate the rest.
+
+## Run it
+
+```bash
+pnpm install
+pnpm --filter @sakthicloud/web build     # typecheck + production build
+pnpm --filter @sakthicloud/web dev        # dev server on :5173
+```
+
+The app talks to the existing Fastify backend. Set the API base in
+`apps/web/.env` (copy `.env.example`); in dev, the Vite proxy forwards `/api`
+to `VITE_API_PROXY` (default `http://localhost:3001`). Log in with a seeded
+account (see the backend's Implementation Guide) to load live data.
+
+## Status / next
+
+- **Done:** toolchain + shell, login + auth (real `/auth/login` + 401 refresh),
+  section nav for all 32 modules, entitlement gating, CSS-variable theming,
+  WS client, and the Rooms slice end-to-end.
+- **Next (per the phased plan):** Bookings + Folio (finish Phase 1 money data),
+  then Housekeeping, then F&B/KDS with real-time — each a repeat of the Rooms slice.
+- **Backend:** carries forward unchanged; migrate `apps/api` (JS→TS) in place.
+  The prototype's caveats still hold until each module's tables land
+  (see `backend/MIGRATION-NOTES.md`).

--- a/sakthicloud/apps/web/.env.example
+++ b/sakthicloud/apps/web/.env.example
@@ -1,0 +1,7 @@
+# Base URL of the Fastify API. Leave empty to call same-origin (/api/v1) in
+# production where the SPA is served by the backend. For local dev the Vite
+# proxy forwards /api to VITE_API_PROXY, so this can stay empty.
+VITE_API_URL=
+
+# Where the dev proxy forwards /api to (local Fastify backend).
+VITE_API_PROXY=http://localhost:3001

--- a/sakthicloud/apps/web/index.html
+++ b/sakthicloud/apps/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SakthiCloud</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/sakthicloud/apps/web/package.json
+++ b/sakthicloud/apps/web/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@sakthicloud/web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "typecheck": "tsc --noEmit",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@sakthicloud/shared": "workspace:*",
+    "@tanstack/react-query": "^5.59.16",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.28.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.3",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.10"
+  }
+}

--- a/sakthicloud/apps/web/src/app/auth-context.tsx
+++ b/sakthicloud/apps/web/src/app/auth-context.tsx
@@ -1,0 +1,85 @@
+import { createContext, useContext, useState, useCallback, type ReactNode } from "react";
+import {
+  LoginResponse,
+  type AuthUser,
+  type Tenant,
+  type PropertyRef,
+  type Subscription,
+  effectiveModulesFor,
+} from "@sakthicloud/shared";
+import { api, setTokens, clearTokens, isAuthenticated } from "@/lib/api-client";
+import { liveChannel } from "@/lib/ws";
+
+interface Session {
+  user: AuthUser;
+  tenant: Tenant;
+  properties: PropertyRef[];
+  activePropertyId: string | null;
+}
+
+interface AuthContextValue {
+  session: Session | null;
+  subscription: Subscription;
+  modules: string[];
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+  setActiveProperty: (id: string) => void;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [session, setSession] = useState<Session | null>(null);
+
+  const login = useCallback(async (email: string, password: string) => {
+    const raw = await api.post<unknown>("/auth/login", { email, password });
+    const data = LoginResponse.parse(raw);
+    setTokens(data.accessToken, data.refreshToken);
+    setSession({
+      user: data.user,
+      tenant: data.tenant,
+      properties: data.properties,
+      activePropertyId: data.properties[0]?.id ?? null,
+    });
+    if (data.tenant.id) liveChannel.connect(data.tenant.id, data.accessToken);
+  }, []);
+
+  const logout = useCallback(async () => {
+    try {
+      await api.post("/auth/logout", {});
+    } catch {
+      /* best-effort */
+    }
+    clearTokens();
+    liveChannel.disconnect();
+    setSession(null);
+  }, []);
+
+  const setActiveProperty = useCallback((id: string) => {
+    setSession((s) => (s ? { ...s, activePropertyId: id } : s));
+  }, []);
+
+  const subscription: Subscription = {
+    plan: session?.tenant.plan ?? "core",
+    addons: session?.tenant.addons ?? [],
+    roomBand: session?.tenant.roomBand ?? "1-20",
+  };
+
+  const modules = session ? effectiveModulesFor(session.user) : [];
+
+  return (
+    <AuthContext.Provider value={{ session, subscription, modules, login, logout, setActiveProperty }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within <AuthProvider>");
+  return ctx;
+}
+
+export function hasStoredSession(): boolean {
+  return isAuthenticated();
+}

--- a/sakthicloud/apps/web/src/app/providers.tsx
+++ b/sakthicloud/apps/web/src/app/providers.tsx
@@ -1,0 +1,30 @@
+import { useEffect, type ReactNode } from "react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { BrowserRouter } from "react-router-dom";
+import { queryClient } from "@/lib/query-client";
+import { AuthProvider } from "./auth-context";
+import { ToastProvider } from "@/components/Toast";
+import { applyTheme, getPreset, DEFAULT_THEME_ID } from "@/lib/theme";
+
+function ThemeProvider({ children }: { children: ReactNode }) {
+  useEffect(() => {
+    // In a full build the active tenant's brand id comes from tenant settings;
+    // default preset until a session with branding loads.
+    applyTheme(getPreset(DEFAULT_THEME_ID));
+  }, []);
+  return <>{children}</>;
+}
+
+export function Providers({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <ThemeProvider>
+          <AuthProvider>
+            <ToastProvider>{children}</ToastProvider>
+          </AuthProvider>
+        </ThemeProvider>
+      </BrowserRouter>
+    </QueryClientProvider>
+  );
+}

--- a/sakthicloud/apps/web/src/app/router.tsx
+++ b/sakthicloud/apps/web/src/app/router.tsx
@@ -1,0 +1,60 @@
+import { lazy, Suspense, type ComponentType, type ReactNode } from "react";
+import { Routes, Route, Navigate, useParams } from "react-router-dom";
+import { isModuleLocked } from "@sakthicloud/shared";
+import { useAuth } from "./auth-context";
+import { AppShell } from "./shell/AppShell";
+import { LoginPage } from "@/features/auth/LoginPage";
+import { UpgradeGate } from "@/components/UpgradeGate";
+import { ModulePlaceholder } from "@/features/_shared/ModulePlaceholder";
+
+// Code-split per module — each feature is its own chunk, loaded on demand and
+// only when the tenant is entitled. This is the payoff over Babel-in-browser:
+// a tenant on Core never downloads the Finance or Spa bundles.
+const RoomsPage = lazy(() =>
+  import("@/features/front-desk/rooms/RoomsPage").then((m) => ({ default: m.RoomsPage })),
+);
+
+/** Feature registry: module id → its lazy component. Grows as modules migrate. */
+const FEATURES: Record<string, ComponentType> = {
+  rooms: RoomsPage,
+};
+
+function ModuleRoute() {
+  const { moduleId = "" } = useParams();
+  const { modules, subscription } = useAuth();
+
+  if (!modules.includes(moduleId)) return <Navigate to="/m/dashboard" replace />;
+  if (isModuleLocked(moduleId, subscription)) return <UpgradeGate moduleId={moduleId} />;
+
+  const Feature = FEATURES[moduleId];
+  return (
+    <Suspense fallback={<div className="sc-loading">Loading…</div>}>
+      {Feature ? <Feature /> : <ModulePlaceholder moduleId={moduleId} />}
+    </Suspense>
+  );
+}
+
+function Protected({ children }: { children: ReactNode }) {
+  const { session } = useAuth();
+  if (!session) return <Navigate to="/login" replace />;
+  return <>{children}</>;
+}
+
+export function AppRouter() {
+  const { session } = useAuth();
+  return (
+    <Routes>
+      <Route path="/login" element={session ? <Navigate to="/m/dashboard" replace /> : <LoginPage />} />
+      <Route
+        element={
+          <Protected>
+            <AppShell />
+          </Protected>
+        }
+      >
+        <Route path="/m/:moduleId" element={<ModuleRoute />} />
+      </Route>
+      <Route path="*" element={<Navigate to={session ? "/m/dashboard" : "/login"} replace />} />
+    </Routes>
+  );
+}

--- a/sakthicloud/apps/web/src/app/router.tsx
+++ b/sakthicloud/apps/web/src/app/router.tsx
@@ -13,10 +13,18 @@ import { ModulePlaceholder } from "@/features/_shared/ModulePlaceholder";
 const RoomsPage = lazy(() =>
   import("@/features/front-desk/rooms/RoomsPage").then((m) => ({ default: m.RoomsPage })),
 );
+const BookingsPage = lazy(() =>
+  import("@/features/front-desk/bookings/BookingsPage").then((m) => ({ default: m.BookingsPage })),
+);
+const FolioPage = lazy(() =>
+  import("@/features/front-desk/folio/FolioPage").then((m) => ({ default: m.FolioPage })),
+);
 
 /** Feature registry: module id → its lazy component. Grows as modules migrate. */
 const FEATURES: Record<string, ComponentType> = {
   rooms: RoomsPage,
+  bookings: BookingsPage,
+  folio: FolioPage,
 };
 
 function ModuleRoute() {

--- a/sakthicloud/apps/web/src/app/shell/AppShell.tsx
+++ b/sakthicloud/apps/web/src/app/shell/AppShell.tsx
@@ -1,0 +1,22 @@
+import { useState } from "react";
+import { Outlet } from "react-router-dom";
+import { Sidebar } from "./Sidebar";
+import { Topbar } from "./Topbar";
+
+export function AppShell() {
+  const [navOpen, setNavOpen] = useState(false);
+  return (
+    <div className={"sc-shell" + (navOpen ? " sc-shell--nav-open" : "")}>
+      <aside className="sc-shell__nav">
+        <Sidebar onNavigate={() => setNavOpen(false)} />
+      </aside>
+      {navOpen && <div className="sc-shell__scrim" onClick={() => setNavOpen(false)} />}
+      <div className="sc-shell__main">
+        <Topbar onToggleNav={() => setNavOpen((v) => !v)} />
+        <main className="sc-shell__content">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/sakthicloud/apps/web/src/app/shell/Sidebar.tsx
+++ b/sakthicloud/apps/web/src/app/shell/Sidebar.tsx
@@ -1,0 +1,48 @@
+import { NavLink } from "react-router-dom";
+import { ALL_NAV, SECTION_ORDER, isModuleLocked, type SectionName } from "@sakthicloud/shared";
+import { useAuth } from "@/app/auth-context";
+
+export function Sidebar({ onNavigate }: { onNavigate?: () => void }) {
+  const { modules, subscription } = useAuth();
+
+  // Only modules the user's role/override grants; grouped by section, in order.
+  const visible = ALL_NAV.filter((n) => modules.includes(n.id));
+  const bySection = new Map<SectionName, typeof visible>();
+  for (const item of visible) {
+    if (!bySection.has(item.sec)) bySection.set(item.sec, []);
+    bySection.get(item.sec)!.push(item);
+  }
+
+  return (
+    <nav className="sc-sidebar" aria-label="Modules">
+      <div className="sc-sidebar__brand">SakthiCloud</div>
+      {SECTION_ORDER.map((section) => {
+        const items = bySection.get(section);
+        if (!items || items.length === 0) return null;
+        return (
+          <div key={section} className="sc-sidebar__section">
+            <div className="sc-sidebar__section-label">{section}</div>
+            {items.map((item) => {
+              const locked = isModuleLocked(item.id, subscription);
+              // Locked add-on modules stay visible (upsell surface); route to the
+              // module, where an UpgradeGate renders instead of the feature.
+              return (
+                <NavLink
+                  key={item.id}
+                  to={`/m/${item.id}`}
+                  onClick={onNavigate}
+                  className={({ isActive }) =>
+                    "sc-navitem" + (isActive ? " sc-navitem--active" : "") + (locked ? " sc-navitem--locked" : "")
+                  }
+                >
+                  <span className="sc-navitem__label">{item.label}</span>
+                  {locked && <span className="sc-navitem__lock" aria-label="Requires upgrade">🔒</span>}
+                </NavLink>
+              );
+            })}
+          </div>
+        );
+      })}
+    </nav>
+  );
+}

--- a/sakthicloud/apps/web/src/app/shell/Topbar.tsx
+++ b/sakthicloud/apps/web/src/app/shell/Topbar.tsx
@@ -1,0 +1,46 @@
+import { useAuth } from "@/app/auth-context";
+
+export function Topbar({ onToggleNav }: { onToggleNav: () => void }) {
+  const { session, logout, setActiveProperty } = useAuth();
+  if (!session) return null;
+
+  const initials = session.user.name
+    .split(" ")
+    .map((w) => w[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+
+  return (
+    <header className="sc-topbar">
+      <button className="sc-iconbtn sc-topbar__menu" onClick={onToggleNav} aria-label="Toggle navigation">
+        ☰
+      </button>
+      <div className="sc-topbar__tenant">{session.tenant.name}</div>
+
+      {session.properties.length > 0 && (
+        <select
+          className="sc-select"
+          value={session.activePropertyId ?? ""}
+          onChange={(e) => setActiveProperty(e.target.value)}
+          aria-label="Active property"
+        >
+          {session.properties.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      )}
+
+      <div className="sc-topbar__spacer" />
+      <div className="sc-topbar__user" title={session.user.email}>
+        <span className="sc-avatar">{initials}</span>
+        <span className="sc-topbar__name">{session.user.name}</span>
+      </div>
+      <button className="sc-btn sc-btn--ghost" onClick={() => void logout()}>
+        Log out
+      </button>
+    </header>
+  );
+}

--- a/sakthicloud/apps/web/src/components/Toast.tsx
+++ b/sakthicloud/apps/web/src/components/Toast.tsx
@@ -1,0 +1,41 @@
+import { createContext, useContext, useState, useCallback, type ReactNode } from "react";
+
+type ToastKind = "success" | "error" | "info";
+interface ToastItem {
+  id: number;
+  kind: ToastKind;
+  message: string;
+}
+
+const ToastContext = createContext<((kind: ToastKind, message: string) => void) | null>(null);
+
+let counter = 0;
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState<ToastItem[]>([]);
+
+  const toast = useCallback((kind: ToastKind, message: string) => {
+    const id = ++counter;
+    setItems((prev) => [...prev, { id, kind, message }]);
+    window.setTimeout(() => setItems((prev) => prev.filter((t) => t.id !== id)), 4000);
+  }, []);
+
+  return (
+    <ToastContext.Provider value={toast}>
+      {children}
+      <div className="sc-toast-stack" role="status" aria-live="polite">
+        {items.map((t) => (
+          <div key={t.id} className={`sc-toast sc-toast--${t.kind}`}>
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToast must be used within <ToastProvider>");
+  return ctx;
+}

--- a/sakthicloud/apps/web/src/components/UpgradeGate.tsx
+++ b/sakthicloud/apps/web/src/components/UpgradeGate.tsx
@@ -1,0 +1,27 @@
+import { Link } from "react-router-dom";
+import { ADDON_CATALOG, moduleAddonId, ALL_NAV } from "@sakthicloud/shared";
+
+// Rendered in place of a locked module. Locked-but-visible is the upsell
+// surface — the backend also enforces this with a 402 on the API, so gating
+// here is UX, not the security boundary.
+export function UpgradeGate({ moduleId }: { moduleId: string }) {
+  const addonId = moduleAddonId(moduleId);
+  const addon = ADDON_CATALOG.find((a) => a.id === addonId);
+  const label = ALL_NAV.find((n) => n.id === moduleId)?.label ?? moduleId;
+
+  return (
+    <div className="sc-upgrade">
+      <div className="sc-upgrade__lock">🔒</div>
+      <h1 className="sc-upgrade__title">{label} is part of {addon?.label ?? "an add-on"}</h1>
+      <p className="sc-upgrade__desc">{addon?.desc}</p>
+      {addon && (
+        <p className="sc-upgrade__price">
+          ₹{addon.price.toLocaleString("en-IN")}<span>/property/month</span>
+        </p>
+      )}
+      <Link to="/m/subscription" className="sc-btn sc-btn--primary">
+        View plans &amp; enable
+      </Link>
+    </div>
+  );
+}

--- a/sakthicloud/apps/web/src/features/_shared/ModulePlaceholder.tsx
+++ b/sakthicloud/apps/web/src/features/_shared/ModulePlaceholder.tsx
@@ -1,0 +1,19 @@
+import { ALL_NAV } from "@sakthicloud/shared";
+
+// Every module the prototype already built maps 1:1 onto a feature folder.
+// Until each is migrated (model → schema → route → hook → component → WS),
+// this placeholder documents the target so the shell is navigable end-to-end.
+export function ModulePlaceholder({ moduleId }: { moduleId: string }) {
+  const meta = ALL_NAV.find((n) => n.id === moduleId);
+  return (
+    <div className="sc-placeholder">
+      <h1 className="sc-placeholder__title">{meta?.label ?? moduleId}</h1>
+      <p className="sc-placeholder__section">{meta?.sec}</p>
+      <p className="sc-placeholder__body">
+        This module is entitled and routed. Its feature folder migrates from the prototype using the
+        same six-part pattern proved by <strong>Rooms</strong>: Prisma model → Zod schema → Fastify
+        route → TanStack Query hook → component → WebSocket live sync.
+      </p>
+    </div>
+  );
+}

--- a/sakthicloud/apps/web/src/features/auth/LoginPage.tsx
+++ b/sakthicloud/apps/web/src/features/auth/LoginPage.tsx
@@ -1,0 +1,64 @@
+import { useState, type FormEvent } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "@/app/auth-context";
+import { ApiError } from "@/lib/api-client";
+
+export function LoginPage() {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setBusy(true);
+    try {
+      await login(email, password);
+      navigate("/m/dashboard", { replace: true });
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Login failed. Check your connection.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="sc-login">
+      <form className="sc-login__card" onSubmit={onSubmit}>
+        <div className="sc-login__brand">SakthiCloud</div>
+        <p className="sc-login__sub">Hotel management, signed in.</p>
+
+        <label className="sc-field">
+          <span>Email</span>
+          <input
+            type="email"
+            autoComplete="username"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </label>
+
+        <label className="sc-field">
+          <span>Password</span>
+          <input
+            type="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </label>
+
+        {error && <div className="sc-login__error">{error}</div>}
+
+        <button type="submit" className="sc-btn sc-btn--primary sc-login__submit" disabled={busy}>
+          {busy ? "Signing in…" : "Sign in"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/sakthicloud/apps/web/src/features/front-desk/bookings/BookingsPage.tsx
+++ b/sakthicloud/apps/web/src/features/front-desk/bookings/BookingsPage.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+import { BookingStatus, type Booking } from "@sakthicloud/shared";
+import { useAuth } from "@/app/auth-context";
+import { useToast } from "@/components/Toast";
+import { useBookings, useCheckOut } from "./hooks";
+import { CheckInModal } from "./components/CheckInModal";
+
+const FILTERS: { label: string; value: BookingStatus | undefined }[] = [
+  { label: "All", value: undefined },
+  { label: "In-house", value: "CHECKED_IN" },
+  { label: "Reserved", value: "RESERVED" },
+  { label: "Departed", value: "CHECKED_OUT" },
+];
+
+export function BookingsPage() {
+  const { session } = useAuth();
+  const toast = useToast();
+  const propertyId = session?.activePropertyId ?? null;
+
+  const [filter, setFilter] = useState<BookingStatus | undefined>(undefined);
+  const [showCheckIn, setShowCheckIn] = useState(false);
+
+  const { data: bookings = [], isLoading, isError, error } = useBookings(propertyId, filter);
+  const checkOutMut = useCheckOut(propertyId ?? "");
+
+  function checkout(b: Booking) {
+    if (!confirm(`Check out ${b.guestName} from room ${b.roomNumber}?`)) return;
+    checkOutMut.mutate(
+      { bookingId: b.id, body: { extras: [], discount: 0, paymentMode: "UPI", sendWhatsApp: false, sendEmail: false } },
+      {
+        onSuccess: () => toast("success", "Checked out"),
+        onError: (e) => toast("error", e instanceof Error ? e.message : "Checkout failed"),
+      },
+    );
+  }
+
+  if (!propertyId) return <div className="sc-empty">Select a property to view bookings.</div>;
+
+  return (
+    <div className="sc-bookings">
+      <header className="sc-rooms__head">
+        <h1>Bookings</h1>
+        <div className="sc-bookings__bar">
+          <div className="sc-filters">
+            {FILTERS.map((f) => (
+              <button
+                key={f.label}
+                className={"sc-pill" + (filter === f.value ? " sc-pill--active" : "")}
+                onClick={() => setFilter(f.value)}
+              >
+                {f.label}
+              </button>
+            ))}
+          </div>
+          <button className="sc-btn sc-btn--primary" onClick={() => setShowCheckIn(true)}>
+            + Check-in
+          </button>
+        </div>
+      </header>
+
+      {isLoading ? (
+        <div className="sc-loading">Loading bookings…</div>
+      ) : isError ? (
+        <div className="sc-empty sc-empty--error">
+          Couldn’t load bookings: {error instanceof Error ? error.message : "unknown error"}
+        </div>
+      ) : bookings.length === 0 ? (
+        <div className="sc-empty">No bookings match this filter.</div>
+      ) : (
+        <div className="sc-table__wrap">
+          <table className="sc-table">
+            <thead>
+              <tr>
+                <th>Guest</th><th>Room</th><th>Stay</th><th>Nights</th>
+                <th className="sc-num">Total</th><th className="sc-num">Balance</th><th>Status</th><th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {bookings.map((b) => (
+                <tr key={b.id}>
+                  <td>
+                    <div className="sc-cell-strong">{b.guestName}</div>
+                    <div className="sc-cell-dim">{b.guestPhone}</div>
+                  </td>
+                  <td>{b.roomNumber} · {b.roomType}</td>
+                  <td className="sc-cell-dim">{b.checkIn} → {b.checkOut}</td>
+                  <td>{b.nights}</td>
+                  <td className="sc-num">₹{b.grandTotal.toLocaleString("en-IN")}</td>
+                  <td className="sc-num">₹{b.balanceDue.toLocaleString("en-IN")}</td>
+                  <td><span className={`sc-badge sc-badge--status-${b.status}`}>{b.status.replace("_", " ").toLowerCase()}</span></td>
+                  <td>
+                    {b.status === "CHECKED_IN" && (
+                      <button className="sc-btn sc-btn--ghost" onClick={() => checkout(b)} disabled={checkOutMut.isPending}>
+                        Check out
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {showCheckIn && <CheckInModal propertyId={propertyId} onClose={() => setShowCheckIn(false)} />}
+    </div>
+  );
+}

--- a/sakthicloud/apps/web/src/features/front-desk/bookings/api.ts
+++ b/sakthicloud/apps/web/src/features/front-desk/bookings/api.ts
@@ -1,0 +1,62 @@
+import { api } from "@/lib/api-client";
+import {
+  BookingsListResponse,
+  Booking,
+  type BookingApiRow,
+  type BookingStatus,
+  type CheckInRequest,
+  type CheckOutRequest,
+} from "@sakthicloud/shared";
+
+export const bookingKeys = {
+  all: ["bookings"] as const,
+  list: (propertyId: string, status?: string) => ["bookings", "list", propertyId, status ?? "all"] as const,
+};
+
+function num(v: string | number | null | undefined, fallback = 0): number {
+  if (v == null) return fallback;
+  const n = typeof v === "string" ? parseFloat(v) : v;
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function nightsBetween(inIso?: string | null, outIso?: string | null): number {
+  if (!inIso || !outIso) return 0;
+  const ms = new Date(outIso).getTime() - new Date(inIso).getTime();
+  return Math.max(0, Math.ceil(ms / 86_400_000));
+}
+
+function flatten(row: BookingApiRow): Booking {
+  return Booking.parse({
+    id: row.id,
+    status: row.status,
+    guestName: row.guest?.name ?? "—",
+    guestPhone: row.guest?.phone ?? "",
+    roomId: null,
+    roomNumber: row.room?.number ?? "—",
+    roomType: row.room?.roomType?.name ?? "Standard",
+    checkIn: (row.checkIn ?? "").split("T")[0],
+    checkOut: (row.checkOut ?? "").split("T")[0],
+    nights: nightsBetween(row.checkIn, row.checkOut),
+    adults: num(row.adults, 1),
+    children: num(row.children, 0),
+    grandTotal: num(row.grandTotal),
+    advancePayment: num(row.advancePayment),
+    balanceDue: num(row.balanceDue),
+    bookingSource: row.bookingSource ?? "Walk-in",
+  });
+}
+
+export async function fetchBookings(propertyId: string, status?: BookingStatus): Promise<Booking[]> {
+  const qs = status ? `?status=${status}` : "";
+  const raw = await api.get<unknown>(`/properties/${propertyId}/bookings${qs}`);
+  const parsed = BookingsListResponse.parse(raw);
+  return parsed.bookings.map(flatten);
+}
+
+export async function checkIn(propertyId: string, body: CheckInRequest): Promise<void> {
+  await api.post(`/properties/${propertyId}/bookings/checkin`, body);
+}
+
+export async function checkOut(bookingId: string, body: CheckOutRequest): Promise<void> {
+  await api.post(`/bookings/${bookingId}/checkout`, body);
+}

--- a/sakthicloud/apps/web/src/features/front-desk/bookings/components/CheckInModal.tsx
+++ b/sakthicloud/apps/web/src/features/front-desk/bookings/components/CheckInModal.tsx
@@ -1,0 +1,112 @@
+import { useMemo, useState, type FormEvent } from "react";
+import { CheckInRequest } from "@sakthicloud/shared";
+import { useRooms } from "../../rooms/hooks";
+import { useCheckIn } from "../hooks";
+import { useToast } from "@/components/Toast";
+import { ApiError } from "@/lib/api-client";
+
+function todayPlus(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d.toISOString().split("T")[0];
+}
+
+export function CheckInModal({ propertyId, onClose }: { propertyId: string; onClose: () => void }) {
+  const toast = useToast();
+  const { data: rooms = [] } = useRooms(propertyId);
+  const checkInMut = useCheckIn(propertyId);
+
+  const available = useMemo(() => rooms.filter((r) => r.status === "available"), [rooms]);
+
+  const [roomId, setRoomId] = useState("");
+  const [name, setName] = useState("");
+  const [phone, setPhone] = useState("");
+  const [idNumber, setIdNumber] = useState("");
+  const [checkIn, setCheckInDate] = useState(todayPlus(0));
+  const [checkOut, setCheckOutDate] = useState(todayPlus(1));
+  const [billingAC, setBillingAC] = useState(true);
+  const [advancePayment, setAdvance] = useState("0");
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    const parsed = CheckInRequest.safeParse({
+      roomId,
+      guest: { name, phone, idNumber, idType: "Aadhaar", nationality: "Indian" },
+      checkIn,
+      checkOut,
+      billingAC,
+      advancePayment: Number(advancePayment) || 0,
+      paymentMode: "UPI",
+      bookingSource: "Walk-in",
+    });
+    if (!parsed.success) {
+      setError(parsed.error.issues[0]?.message ?? "Please check the form");
+      return;
+    }
+    try {
+      await checkInMut.mutateAsync(parsed.data);
+      toast("success", "Guest checked in");
+      onClose();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Check-in failed");
+    }
+  }
+
+  return (
+    <div className="sc-modal__backdrop" onClick={onClose}>
+      <form className="sc-modal" onClick={(e) => e.stopPropagation()} onSubmit={onSubmit}>
+        <h2 className="sc-modal__title">New check-in</h2>
+
+        <label className="sc-field">
+          <span>Room</span>
+          <select className="sc-select" value={roomId} onChange={(e) => setRoomId(e.target.value)} required>
+            <option value="">Select an available room…</option>
+            {available.map((r) => (
+              <option key={r.id} value={r.id}>
+                {r.number} · {r.type} · ₹{r.rate.toLocaleString("en-IN")}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="sc-grid2">
+          <label className="sc-field"><span>Guest name</span>
+            <input value={name} onChange={(e) => setName(e.target.value)} required /></label>
+          <label className="sc-field"><span>Phone</span>
+            <input value={phone} onChange={(e) => setPhone(e.target.value)} required /></label>
+        </div>
+
+        <label className="sc-field"><span>ID number</span>
+          <input value={idNumber} onChange={(e) => setIdNumber(e.target.value)} required /></label>
+
+        <div className="sc-grid2">
+          <label className="sc-field"><span>Check-in</span>
+            <input type="date" value={checkIn} onChange={(e) => setCheckInDate(e.target.value)} required /></label>
+          <label className="sc-field"><span>Check-out</span>
+            <input type="date" value={checkOut} onChange={(e) => setCheckOutDate(e.target.value)} required /></label>
+        </div>
+
+        <div className="sc-grid2">
+          <label className="sc-field"><span>Advance (₹)</span>
+            <input type="number" min="0" value={advancePayment} onChange={(e) => setAdvance(e.target.value)} /></label>
+          <label className="sc-field sc-field--inline">
+            <input type="checkbox" checked={billingAC} onChange={(e) => setBillingAC(e.target.checked)} />
+            <span>AC tariff</span>
+          </label>
+        </div>
+
+        {available.length === 0 && <div className="sc-login__error">No rooms are currently available.</div>}
+        {error && <div className="sc-login__error">{error}</div>}
+
+        <div className="sc-modal__actions">
+          <button type="button" className="sc-btn sc-btn--ghost" onClick={onClose}>Cancel</button>
+          <button type="submit" className="sc-btn sc-btn--primary" disabled={checkInMut.isPending}>
+            {checkInMut.isPending ? "Checking in…" : "Check in"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/sakthicloud/apps/web/src/features/front-desk/bookings/hooks.ts
+++ b/sakthicloud/apps/web/src/features/front-desk/bookings/hooks.ts
@@ -1,0 +1,47 @@
+import { useEffect } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import type { BookingStatus, CheckInRequest, CheckOutRequest } from "@sakthicloud/shared";
+import { invalidateOn } from "@/lib/ws";
+import { roomKeys } from "../rooms/api";
+import { bookingKeys, fetchBookings, checkIn, checkOut } from "./api";
+
+export function useBookings(propertyId: string | null, status?: BookingStatus) {
+  const query = useQuery({
+    queryKey: bookingKeys.list(propertyId ?? "none", status),
+    queryFn: () => fetchBookings(propertyId!, status),
+    enabled: !!propertyId,
+  });
+
+  useEffect(() => {
+    if (!propertyId) return;
+    // A booking change on any device (check-in/out) refreshes every board.
+    return invalidateOn("booking:updated", bookingKeys.list(propertyId, status));
+  }, [propertyId, status]);
+
+  return query;
+}
+
+// Check-in and check-out both move a room between available/occupied, so they
+// invalidate BOTH the bookings and rooms caches — the room board stays truthful.
+export function useCheckIn(propertyId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CheckInRequest) => checkIn(propertyId, body),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: bookingKeys.all });
+      void qc.invalidateQueries({ queryKey: roomKeys.list(propertyId) });
+    },
+  });
+}
+
+export function useCheckOut(propertyId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ bookingId, body }: { bookingId: string; body: CheckOutRequest }) =>
+      checkOut(bookingId, body),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: bookingKeys.all });
+      void qc.invalidateQueries({ queryKey: roomKeys.list(propertyId) });
+    },
+  });
+}

--- a/sakthicloud/apps/web/src/features/front-desk/folio/FolioPage.tsx
+++ b/sakthicloud/apps/web/src/features/front-desk/folio/FolioPage.tsx
@@ -1,0 +1,118 @@
+import { useMemo, useState } from "react";
+import { FOLIO_CATEGORIES, type Booking, type FolioLine } from "@sakthicloud/shared";
+import { useAuth } from "@/app/auth-context";
+import { useBookings } from "../bookings/hooks";
+
+// The running bill per in-house guest. Room charge + GST come from the booking
+// (real, server-persisted). Incidental lines are session-local for now — the
+// same honest caveat as the prototype — until folio_line / folio_payment land
+// (see packages/shared/schemas/folio.ts and the persistence backlog).
+
+type LocalLine = Pick<FolioLine, "id" | "category" | "description" | "amount" | "gstRate">;
+
+export function FolioPage() {
+  const { session } = useAuth();
+  const propertyId = session?.activePropertyId ?? null;
+  const { data: inHouse = [], isLoading } = useBookings(propertyId, "CHECKED_IN");
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [lines, setLines] = useState<Record<string, LocalLine[]>>({});
+
+  const selected = inHouse.find((b) => b.id === selectedId) ?? inHouse[0] ?? null;
+
+  if (!propertyId) return <div className="sc-empty">Select a property to view folios.</div>;
+  if (isLoading) return <div className="sc-loading">Loading folios…</div>;
+  if (inHouse.length === 0) return <div className="sc-empty">No in-house guests right now.</div>;
+
+  return (
+    <div className="sc-folio">
+      <aside className="sc-folio__list">
+        {inHouse.map((b) => (
+          <button
+            key={b.id}
+            className={"sc-folio__guest" + ((selected?.id === b.id) ? " sc-folio__guest--active" : "")}
+            onClick={() => setSelectedId(b.id)}
+          >
+            <div className="sc-cell-strong">{b.guestName}</div>
+            <div className="sc-cell-dim">Room {b.roomNumber} · bal ₹{b.balanceDue.toLocaleString("en-IN")}</div>
+          </button>
+        ))}
+      </aside>
+
+      {selected && (
+        <FolioDetail
+          booking={selected}
+          lines={lines[selected.id] ?? []}
+          onAdd={(line) => setLines((m) => ({ ...m, [selected.id]: [...(m[selected.id] ?? []), line] }))}
+        />
+      )}
+    </div>
+  );
+}
+
+function FolioDetail({
+  booking,
+  lines,
+  onAdd,
+}: {
+  booking: Booking;
+  lines: LocalLine[];
+  onAdd: (line: LocalLine) => void;
+}) {
+  const [category, setCategory] = useState<(typeof FOLIO_CATEGORIES)[number]>("Food & Beverage");
+  const [amount, setAmount] = useState("");
+  const [gstRate, setGstRate] = useState("5");
+
+  const incidentalTotal = useMemo(
+    () => lines.reduce((sum, l) => sum + l.amount + (l.amount * l.gstRate) / 100, 0),
+    [lines],
+  );
+  const grand = booking.grandTotal + incidentalTotal;
+  const balance = grand - booking.advancePayment;
+
+  function add() {
+    const amt = Number(amount);
+    if (!amt || amt <= 0) return;
+    onAdd({ id: `local-${Date.now()}`, category, description: "", amount: amt, gstRate: Number(gstRate) || 0 });
+    setAmount("");
+  }
+
+  return (
+    <section className="sc-folio__detail">
+      <header>
+        <h1>{booking.guestName}</h1>
+        <div className="sc-cell-dim">Room {booking.roomNumber} · {booking.roomType} · {booking.nights} nights</div>
+      </header>
+
+      <table className="sc-table">
+        <tbody>
+          <tr><td>Room charge (incl. GST)</td><td className="sc-num">₹{booking.grandTotal.toLocaleString("en-IN")}</td></tr>
+          {lines.map((l) => (
+            <tr key={l.id}>
+              <td>{l.category} <span className="sc-cell-dim">+{l.gstRate}% GST</span></td>
+              <td className="sc-num">₹{(l.amount + (l.amount * l.gstRate) / 100).toLocaleString("en-IN")}</td>
+            </tr>
+          ))}
+          <tr className="sc-table__total"><td>Grand total</td><td className="sc-num">₹{grand.toLocaleString("en-IN")}</td></tr>
+          <tr><td>Advance paid</td><td className="sc-num">− ₹{booking.advancePayment.toLocaleString("en-IN")}</td></tr>
+          <tr className="sc-table__total"><td>Balance due</td><td className="sc-num">₹{balance.toLocaleString("en-IN")}</td></tr>
+        </tbody>
+      </table>
+
+      <div className="sc-folio__post">
+        <select className="sc-select" value={category} onChange={(e) => setCategory(e.target.value as typeof category)}>
+          {FOLIO_CATEGORIES.filter((c) => c !== "Room Charge").map((c) => <option key={c} value={c}>{c}</option>)}
+        </select>
+        <input className="sc-select" type="number" min="0" placeholder="Amount" value={amount} onChange={(e) => setAmount(e.target.value)} />
+        <select className="sc-select" value={gstRate} onChange={(e) => setGstRate(e.target.value)}>
+          <option value="0">0%</option><option value="5">5%</option><option value="12">12%</option><option value="18">18%</option>
+        </select>
+        <button className="sc-btn sc-btn--primary" onClick={add}>Post charge</button>
+      </div>
+      <p className="sc-cell-dim sc-folio__note">
+        Incidental charges are session-local until the folio_line / folio_payment tables land. Room
+        charge and advance are server-persisted from the booking.
+      </p>
+    </section>
+  );
+}

--- a/sakthicloud/apps/web/src/features/front-desk/rooms/RoomsPage.tsx
+++ b/sakthicloud/apps/web/src/features/front-desk/rooms/RoomsPage.tsx
@@ -1,0 +1,79 @@
+import { useMemo } from "react";
+import type { Room, CleanStatus } from "@sakthicloud/shared";
+import { useAuth } from "@/app/auth-context";
+import { useToast } from "@/components/Toast";
+import { useRooms, useUpdateRoom } from "./hooks";
+import { RoomCard } from "./components/RoomCard";
+
+const CLEAN_CYCLE: Record<CleanStatus, CleanStatus> = {
+  dirty: "clean",
+  clean: "inspected",
+  inspected: "dirty",
+};
+
+export function RoomsPage() {
+  const { session } = useAuth();
+  const toast = useToast();
+  const propertyId = session?.activePropertyId ?? null;
+
+  const { data: rooms = [], isLoading, isError, error } = useRooms(propertyId);
+  const update = useUpdateRoom(propertyId ?? "");
+
+  const stats = useMemo(() => {
+    const total = rooms.length;
+    const occupied = rooms.filter((r) => r.status === "occupied").length;
+    const dirty = rooms.filter((r) => r.cleanStatus === "dirty").length;
+    const occupancy = total ? Math.round((occupied / total) * 100) : 0;
+    return { total, occupied, dirty, occupancy };
+  }, [rooms]);
+
+  function cycleClean(room: Room) {
+    update.mutate(
+      { roomId: room.id, patch: { cleanStatus: CLEAN_CYCLE[room.cleanStatus] } },
+      { onError: (e) => toast("error", e instanceof Error ? e.message : "Update failed") },
+    );
+  }
+
+  if (!propertyId) return <div className="sc-empty">Select a property to view rooms.</div>;
+  if (isLoading) return <div className="sc-loading">Loading rooms…</div>;
+  if (isError) {
+    return (
+      <div className="sc-empty sc-empty--error">
+        Couldn’t load rooms: {error instanceof Error ? error.message : "unknown error"}
+      </div>
+    );
+  }
+
+  return (
+    <div className="sc-rooms">
+      <header className="sc-rooms__head">
+        <h1>Rooms</h1>
+        <div className="sc-statrow">
+          <Stat label="Rooms" value={stats.total} />
+          <Stat label="Occupied" value={stats.occupied} />
+          <Stat label="Occupancy" value={`${stats.occupancy}%`} />
+          <Stat label="Dirty" value={stats.dirty} />
+        </div>
+      </header>
+
+      {rooms.length === 0 ? (
+        <div className="sc-empty">No rooms configured for this property yet.</div>
+      ) : (
+        <div className="sc-rooms__grid">
+          {rooms.map((room) => (
+            <RoomCard key={room.id} room={room} onCycleClean={cycleClean} busy={update.isPending} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="sc-stat">
+      <div className="sc-stat__value">{value}</div>
+      <div className="sc-stat__label">{label}</div>
+    </div>
+  );
+}

--- a/sakthicloud/apps/web/src/features/front-desk/rooms/api.ts
+++ b/sakthicloud/apps/web/src/features/front-desk/rooms/api.ts
@@ -1,0 +1,72 @@
+import { api } from "@/lib/api-client";
+import { Room, type RoomApiRow, type UpdateRoomRequest } from "@sakthicloud/shared";
+
+// Query keys — colocated so cache invalidation (manual + via WS) is unambiguous.
+export const roomKeys = {
+  all: ["rooms"] as const,
+  list: (propertyId: string) => ["rooms", "list", propertyId] as const,
+};
+
+function num(v: string | number | null | undefined, fallback = 0): number {
+  if (v == null) return fallback;
+  const n = typeof v === "string" ? parseFloat(v) : v;
+  return Number.isFinite(n) ? n : fallback;
+}
+
+// Flatten the nested Prisma row (roomType, bookings[]) into the app-facing Room.
+// This is the prototype's mapRoom(), now typed and validated once at the boundary.
+function flatten(row: RoomApiRow): Room {
+  const booking = (row.bookings ?? [])[0] as
+    | { guest?: Record<string, unknown>; checkIn?: string; checkOut?: string; adults?: number; children?: number; advancePayment?: number; paymentMode?: string; purpose?: string; id?: string }
+    | undefined;
+  const g = booking?.guest;
+
+  const shaped = {
+    id: row.id,
+    number: row.number,
+    type: row.roomType?.name ?? "Standard",
+    propertyId: row.propertyId,
+    floor: row.floor ?? "",
+    rate: num(row.currentRate ?? row.roomType?.rateAC),
+    rateAC: num(row.roomType?.rateAC),
+    rateNonAC: num(row.roomType?.rateNonAC),
+    gstRate: num(row.roomType?.gstRate, 12),
+    status: (row.status ?? "AVAILABLE").toLowerCase(),
+    cleanStatus: (row.cleanStatus ?? "CLEAN").toLowerCase(),
+    amenities: row.roomType?.amenities ?? ["AC", "TV", "Wi-Fi"],
+    notes: row.notes ?? "",
+    guest: g
+      ? {
+          name: String(g.name ?? ""),
+          phone: String(g.phone ?? ""),
+          email: String(g.email ?? ""),
+          idType: String(g.idType ?? "Aadhaar"),
+          idNumber: String(g.idNumber ?? ""),
+          nationality: String(g.nationality ?? "Indian"),
+          adults: Number(booking?.adults ?? 1),
+          children: Number(booking?.children ?? 0),
+          checkIn: (booking?.checkIn ?? "").split("T")[0],
+          checkOut: (booking?.checkOut ?? "").split("T")[0],
+          advancePayment: Number(booking?.advancePayment ?? 0),
+          paymentMode: String(booking?.paymentMode ?? "UPI"),
+          purpose: String(booking?.purpose ?? "Business"),
+          bookingId: booking?.id,
+        }
+      : null,
+  };
+  // Validate at the trust boundary; downstream code gets a fully-typed Room.
+  return Room.parse(shaped);
+}
+
+export async function fetchRooms(propertyId: string): Promise<Room[]> {
+  const rows = await api.get<RoomApiRow[]>(`/properties/${propertyId}/rooms`);
+  return (rows ?? []).map(flatten);
+}
+
+export async function updateRoom(
+  propertyId: string,
+  roomId: string,
+  patch: UpdateRoomRequest,
+): Promise<void> {
+  await api.put(`/properties/${propertyId}/rooms/${roomId}`, patch);
+}

--- a/sakthicloud/apps/web/src/features/front-desk/rooms/components/RoomCard.tsx
+++ b/sakthicloud/apps/web/src/features/front-desk/rooms/components/RoomCard.tsx
@@ -1,0 +1,48 @@
+import type { Room, RoomStatus } from "@sakthicloud/shared";
+
+const STATUS_LABEL: Record<RoomStatus, string> = {
+  available: "Available",
+  occupied: "Occupied",
+  reserved: "Reserved",
+  maintenance: "Maintenance",
+};
+
+export function RoomCard({
+  room,
+  onCycleClean,
+  busy,
+}: {
+  room: Room;
+  onCycleClean: (room: Room) => void;
+  busy: boolean;
+}) {
+  return (
+    <div className={`sc-room sc-room--${room.status}`}>
+      <div className="sc-room__top">
+        <span className="sc-room__number">{room.number}</span>
+        <span className={`sc-badge sc-badge--${room.status}`}>{STATUS_LABEL[room.status]}</span>
+      </div>
+      <div className="sc-room__type">{room.type}</div>
+      <div className="sc-room__rate">₹{room.rate.toLocaleString("en-IN")}/night</div>
+
+      {room.guest ? (
+        <div className="sc-room__guest">
+          <div className="sc-room__guest-name">{room.guest.name}</div>
+          <div className="sc-room__guest-meta">
+            {room.guest.checkOut ? `Out ${room.guest.checkOut}` : ""}
+          </div>
+        </div>
+      ) : (
+        <div className="sc-room__guest sc-room__guest--empty">No guest</div>
+      )}
+
+      <button
+        className="sc-btn sc-btn--ghost sc-room__clean"
+        onClick={() => onCycleClean(room)}
+        disabled={busy}
+      >
+        Housekeeping: {room.cleanStatus}
+      </button>
+    </div>
+  );
+}

--- a/sakthicloud/apps/web/src/features/front-desk/rooms/hooks.ts
+++ b/sakthicloud/apps/web/src/features/front-desk/rooms/hooks.ts
@@ -1,0 +1,52 @@
+import { useEffect } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import type { Room, UpdateRoomRequest } from "@sakthicloud/shared";
+import { invalidateOn } from "@/lib/ws";
+import { roomKeys, fetchRooms, updateRoom } from "./api";
+
+// Replaces the prototype's `const [rooms, setRooms] = useState(seed)`.
+// Server is the source of truth; the cache is shared across every device and
+// receptionist, and survives refresh — the persistence fix, for free.
+export function useRooms(propertyId: string | null) {
+  const query = useQuery({
+    queryKey: roomKeys.list(propertyId ?? "none"),
+    queryFn: () => fetchRooms(propertyId!),
+    enabled: !!propertyId,
+  });
+
+  // Live board: when any device changes a room, the server broadcasts and every
+  // other device refetches — two receptionists share one live room board.
+  useEffect(() => {
+    if (!propertyId) return;
+    const off = invalidateOn("room:updated", roomKeys.list(propertyId));
+    return off;
+  }, [propertyId]);
+
+  return query;
+}
+
+export function useUpdateRoom(propertyId: string) {
+  const qc = useQueryClient();
+  const key = roomKeys.list(propertyId);
+
+  return useMutation({
+    mutationFn: ({ roomId, patch }: { roomId: string; patch: UpdateRoomRequest }) =>
+      updateRoom(propertyId, roomId, patch),
+
+    // Optimistic: the board feels instant and rolls back on error.
+    onMutate: async ({ roomId, patch }) => {
+      await qc.cancelQueries({ queryKey: key });
+      const prev = qc.getQueryData<Room[]>(key);
+      qc.setQueryData<Room[]>(key, (old) =>
+        old?.map((r) => (r.id === roomId ? { ...r, ...patch } : r)),
+      );
+      return { prev };
+    },
+    onError: (_e, _v, ctx) => {
+      if (ctx?.prev) qc.setQueryData(key, ctx.prev);
+    },
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: key });
+    },
+  });
+}

--- a/sakthicloud/apps/web/src/lib/api-client.ts
+++ b/sakthicloud/apps/web/src/lib/api-client.ts
@@ -1,0 +1,116 @@
+// Typed fetch wrapper — auth header, transparent 401 refresh, structured errors.
+// This is the production version of the prototype's hand-rolled `req()` in the
+// single HTML file, now typed and centralised.
+
+import { RefreshResponse } from "@sakthicloud/shared";
+
+const API_URL = import.meta.env.VITE_API_URL ?? "";
+const BASE = `${API_URL}/api/v1`;
+
+const ACCESS_KEY = "sc_a";
+const REFRESH_KEY = "sc_r";
+
+let accessToken: string | null = null;
+let refreshToken: string | null = null;
+
+function loadTokens() {
+  try {
+    accessToken = accessToken ?? sessionStorage.getItem(ACCESS_KEY);
+    refreshToken = refreshToken ?? sessionStorage.getItem(REFRESH_KEY);
+  } catch {
+    /* storage unavailable */
+  }
+}
+loadTokens();
+
+export function setTokens(access: string, refresh: string) {
+  accessToken = access;
+  refreshToken = refresh;
+  try {
+    sessionStorage.setItem(ACCESS_KEY, access);
+    sessionStorage.setItem(REFRESH_KEY, refresh);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function clearTokens() {
+  accessToken = null;
+  refreshToken = null;
+  try {
+    sessionStorage.removeItem(ACCESS_KEY);
+    sessionStorage.removeItem(REFRESH_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function isAuthenticated(): boolean {
+  return !!accessToken;
+}
+
+export class ApiError extends Error {
+  status: number;
+  details: unknown;
+  constructor(status: number, message: string, details?: unknown) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.details = details;
+  }
+}
+
+type Method = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+async function attemptRefresh(): Promise<boolean> {
+  if (!refreshToken) return false;
+  try {
+    const res = await fetch(`${BASE}/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken }),
+    });
+    if (!res.ok) return false;
+    const data = RefreshResponse.parse(await res.json());
+    setTokens(data.accessToken, data.refreshToken);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function request<T>(method: Method, path: string, body?: unknown, retry = false): Promise<T> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (accessToken) headers["Authorization"] = `Bearer ${accessToken}`;
+
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers,
+    body: body === undefined || body === null ? undefined : JSON.stringify(body),
+  });
+
+  if (res.status === 401 && !retry && refreshToken) {
+    const ok = await attemptRefresh();
+    if (ok) return request<T>(method, path, body, true);
+    clearTokens();
+    throw new ApiError(401, "Session expired. Please log in again.");
+  }
+
+  if (res.status === 204) return null as T;
+
+  const data = await res.json().catch(() => null);
+  if (!res.ok) {
+    const message = (data && (data.error as string)) || "Request failed";
+    // 402 = entitlement missing; the payload carries { addon, upgrade } for the UpgradeGate.
+    throw new ApiError(res.status, message, data);
+  }
+  return data as T;
+}
+
+export const api = {
+  get: <T>(path: string) => request<T>("GET", path),
+  post: <T>(path: string, body?: unknown) => request<T>("POST", path, body),
+  put: <T>(path: string, body?: unknown) => request<T>("PUT", path, body),
+  patch: <T>(path: string, body?: unknown) => request<T>("PATCH", path, body),
+  del: <T>(path: string) => request<T>("DELETE", path),
+};

--- a/sakthicloud/apps/web/src/lib/entitlements.ts
+++ b/sakthicloud/apps/web/src/lib/entitlements.ts
@@ -1,0 +1,12 @@
+// Re-export the shared entitlement contract so features import from one place.
+// The map itself lives in @sakthicloud/shared and is identical to the backend's
+// config/entitlements.js — one definition, both sides.
+export {
+  ADDON_CATALOG,
+  ROOM_BANDS,
+  MODULE_ADDON,
+  moduleAddonId,
+  isCoreModule,
+  isModuleLocked,
+} from "@sakthicloud/shared";
+export type { AddonDef, RoomBand, Subscription } from "@sakthicloud/shared";

--- a/sakthicloud/apps/web/src/lib/query-client.ts
+++ b/sakthicloud/apps/web/src/lib/query-client.ts
@@ -1,0 +1,19 @@
+import { QueryClient } from "@tanstack/react-query";
+import { ApiError } from "./api-client";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      retry: (failureCount, error) => {
+        // Never retry auth/entitlement failures — they won't fix themselves.
+        if (error instanceof ApiError && [401, 402, 403, 404].includes(error.status)) return false;
+        return failureCount < 2;
+      },
+      refetchOnWindowFocus: true,
+    },
+    mutations: {
+      retry: false,
+    },
+  },
+});

--- a/sakthicloud/apps/web/src/lib/theme.ts
+++ b/sakthicloud/apps/web/src/lib/theme.ts
@@ -1,0 +1,70 @@
+// Per-tenant white-label theming via CSS variables. The prototype carried 16
+// inline-style theme objects; here each becomes a token set applied to :root,
+// so switching a tenant's brand is just swapping variable values (no re-render
+// of styled components). Three representative presets are included; the full 16
+// port over as more token sets with zero structural change.
+
+export interface ThemeTokens {
+  bg: string;
+  surface: string;
+  surfaceAlt: string;
+  border: string;
+  text: string;
+  dim: string;
+  primary: string;
+  primaryText: string;
+  accent: string;
+  ok: string;
+  warn: string;
+  danger: string;
+}
+
+export interface ThemePreset {
+  id: string;
+  name: string;
+  tokens: ThemeTokens;
+}
+
+export const THEME_PRESETS: ThemePreset[] = [
+  {
+    id: "sakthi-ivory",
+    name: "Sakthi Ivory",
+    tokens: {
+      bg: "#f6f3ec", surface: "#fffdf8", surfaceAlt: "#f1ece0", border: "#e4ddcd",
+      text: "#2c2a24", dim: "#7a7364", primary: "#8a6d3b", primaryText: "#fffdf8",
+      accent: "#b8925a", ok: "#4b8b5a", warn: "#c08a2d", danger: "#b4513f",
+    },
+  },
+  {
+    id: "royal-porcelain",
+    name: "Royal Porcelain",
+    tokens: {
+      bg: "#f2f4f8", surface: "#ffffff", surfaceAlt: "#eaeef5", border: "#dbe1ec",
+      text: "#1f2733", dim: "#66707f", primary: "#2f4a7c", primaryText: "#ffffff",
+      accent: "#5b7bb4", ok: "#3f8f6a", warn: "#c08a2d", danger: "#c0473f",
+    },
+  },
+  {
+    id: "emerald-garden",
+    name: "Emerald Garden",
+    tokens: {
+      bg: "#f1f6f2", surface: "#ffffff", surfaceAlt: "#e6efe8", border: "#d5e4d8",
+      text: "#20302a", dim: "#5f7168", primary: "#2c6b4f", primaryText: "#ffffff",
+      accent: "#559a76", ok: "#3f8f6a", warn: "#c08a2d", danger: "#c0473f",
+    },
+  },
+];
+
+export const DEFAULT_THEME_ID = "sakthi-ivory";
+
+export function applyTheme(preset: ThemePreset) {
+  const root = document.documentElement;
+  for (const [key, value] of Object.entries(preset.tokens)) {
+    root.style.setProperty(`--sc-${key}`, value);
+  }
+  root.dataset.theme = preset.id;
+}
+
+export function getPreset(id: string): ThemePreset {
+  return THEME_PRESETS.find((p) => p.id === id) ?? THEME_PRESETS[0];
+}

--- a/sakthicloud/apps/web/src/lib/ws.ts
+++ b/sakthicloud/apps/web/src/lib/ws.ts
@@ -1,0 +1,75 @@
+// Per-tenant WebSocket client. The backend already exposes services/websocket.js
+// which broadcasts on a per-tenant channel (e.g. "restaurant:order:created",
+// "kitchen:ticket:new"). Features subscribe and invalidate the matching query,
+// so a KOT fired on the floor lights up the KDS on another device within a
+// second — the piece in-memory useState could never do.
+
+import { queryClient } from "./query-client";
+
+type Listener = (payload: unknown) => void;
+
+class LiveChannel {
+  private ws: WebSocket | null = null;
+  private listeners = new Map<string, Set<Listener>>();
+  private reconnectTimer: number | null = null;
+  private url = "";
+
+  connect(tenantId: string, token: string) {
+    const proto = location.protocol === "https:" ? "wss" : "ws";
+    const apiUrl = import.meta.env.VITE_API_URL ?? "";
+    const host = apiUrl.replace(/^https?:\/\//, "") || location.host;
+    this.url = `${proto}://${host}/ws?tenant=${encodeURIComponent(tenantId)}&token=${encodeURIComponent(token)}`;
+    this.open();
+  }
+
+  private open() {
+    if (!this.url) return;
+    try {
+      this.ws = new WebSocket(this.url);
+    } catch {
+      this.scheduleReconnect();
+      return;
+    }
+    this.ws.onmessage = (ev) => {
+      try {
+        const { event, payload } = JSON.parse(ev.data) as { event: string; payload: unknown };
+        this.listeners.get(event)?.forEach((fn) => fn(payload));
+      } catch {
+        /* ignore malformed frame */
+      }
+    };
+    this.ws.onclose = () => this.scheduleReconnect();
+    this.ws.onerror = () => this.ws?.close();
+  }
+
+  private scheduleReconnect() {
+    if (this.reconnectTimer != null) return;
+    this.reconnectTimer = window.setTimeout(() => {
+      this.reconnectTimer = null;
+      this.open();
+    }, 3000);
+  }
+
+  on(event: string, fn: Listener): () => void {
+    if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+    this.listeners.get(event)!.add(fn);
+    return () => this.listeners.get(event)?.delete(fn);
+  }
+
+  disconnect() {
+    if (this.reconnectTimer != null) window.clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = null;
+    this.url = "";
+    this.ws?.close();
+    this.ws = null;
+  }
+}
+
+export const liveChannel = new LiveChannel();
+
+/** Convenience: invalidate a query key whenever a WS event arrives. */
+export function invalidateOn(event: string, queryKey: readonly unknown[]): () => void {
+  return liveChannel.on(event, () => {
+    void queryClient.invalidateQueries({ queryKey });
+  });
+}

--- a/sakthicloud/apps/web/src/main.tsx
+++ b/sakthicloud/apps/web/src/main.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { Providers } from "./app/providers";
+import { AppRouter } from "./app/router";
+import "./styles.css";
+
+const el = document.getElementById("root");
+if (!el) throw new Error("#root not found");
+
+createRoot(el).render(
+  <StrictMode>
+    <Providers>
+      <AppRouter />
+    </Providers>
+  </StrictMode>,
+);

--- a/sakthicloud/apps/web/src/styles.css
+++ b/sakthicloud/apps/web/src/styles.css
@@ -1,0 +1,149 @@
+:root {
+  /* Fallback tokens; applyTheme() overrides these per tenant brand at runtime. */
+  --sc-bg: #f6f3ec;
+  --sc-surface: #fffdf8;
+  --sc-surfaceAlt: #f1ece0;
+  --sc-border: #e4ddcd;
+  --sc-text: #2c2a24;
+  --sc-dim: #7a7364;
+  --sc-primary: #8a6d3b;
+  --sc-primaryText: #fffdf8;
+  --sc-accent: #b8925a;
+  --sc-ok: #4b8b5a;
+  --sc-warn: #c08a2d;
+  --sc-danger: #b4513f;
+
+  --sc-nav-w: 248px;
+  --sc-radius: 12px;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: var(--sc-text);
+}
+
+* { box-sizing: border-box; }
+html, body, #root { height: 100%; margin: 0; }
+body { background: var(--sc-bg); }
+
+/* ── Buttons / fields ───────────────────────────────────────── */
+.sc-btn {
+  border: 1px solid var(--sc-border);
+  background: var(--sc-surface);
+  color: var(--sc-text);
+  padding: 9px 16px;
+  border-radius: 9px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: filter .12s ease;
+}
+.sc-btn:hover { filter: brightness(0.97); }
+.sc-btn:disabled { opacity: .55; cursor: default; }
+.sc-btn--primary { background: var(--sc-primary); color: var(--sc-primaryText); border-color: transparent; }
+.sc-btn--ghost { background: transparent; }
+.sc-iconbtn { border: none; background: transparent; font-size: 20px; cursor: pointer; color: var(--sc-text); }
+.sc-select {
+  border: 1px solid var(--sc-border); background: var(--sc-surface); color: var(--sc-text);
+  padding: 7px 10px; border-radius: 8px; font-size: 13px;
+}
+.sc-field { display: flex; flex-direction: column; gap: 6px; margin-bottom: 14px; font-size: 13px; color: var(--sc-dim); }
+.sc-field input {
+  padding: 10px 12px; border: 1px solid var(--sc-border); border-radius: 9px;
+  background: var(--sc-surface); color: var(--sc-text); font-size: 15px;
+}
+
+/* ── Login ──────────────────────────────────────────────────── */
+.sc-login { min-height: 100%; display: grid; place-items: center; padding: 24px;
+  background: linear-gradient(160deg, var(--sc-surfaceAlt), var(--sc-bg)); }
+.sc-login__card { width: 100%; max-width: 380px; background: var(--sc-surface);
+  border: 1px solid var(--sc-border); border-radius: 16px; padding: 32px; box-shadow: 0 20px 50px -30px rgba(0,0,0,.4); }
+.sc-login__brand { font-size: 26px; font-weight: 700; color: var(--sc-primary); }
+.sc-login__sub { color: var(--sc-dim); margin: 4px 0 24px; font-size: 14px; }
+.sc-login__submit { width: 100%; margin-top: 6px; }
+.sc-login__error { color: var(--sc-danger); font-size: 13px; margin-bottom: 12px; }
+
+/* ── Shell ──────────────────────────────────────────────────── */
+.sc-shell { display: flex; height: 100%; }
+.sc-shell__nav { width: var(--sc-nav-w); flex: 0 0 var(--sc-nav-w); border-right: 1px solid var(--sc-border);
+  background: var(--sc-surface); overflow-y: auto; }
+.sc-shell__main { flex: 1; display: flex; flex-direction: column; min-width: 0; }
+.sc-shell__content { padding: 24px; overflow-y: auto; flex: 1; }
+.sc-shell__scrim { display: none; }
+
+.sc-sidebar__brand { font-weight: 700; font-size: 18px; color: var(--sc-primary); padding: 18px 20px; }
+.sc-sidebar__section { padding: 6px 10px; }
+.sc-sidebar__section-label { font-size: 11px; text-transform: uppercase; letter-spacing: .06em;
+  color: var(--sc-dim); padding: 8px 10px 4px; }
+.sc-navitem { display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  padding: 8px 10px; border-radius: 8px; text-decoration: none; color: var(--sc-text); font-size: 14px; }
+.sc-navitem:hover { background: var(--sc-surfaceAlt); }
+.sc-navitem--active { background: var(--sc-primary); color: var(--sc-primaryText); }
+.sc-navitem--locked { color: var(--sc-dim); }
+.sc-navitem__lock { font-size: 12px; }
+
+.sc-topbar { display: flex; align-items: center; gap: 14px; padding: 12px 20px;
+  border-bottom: 1px solid var(--sc-border); background: var(--sc-surface); }
+.sc-topbar__tenant { font-weight: 600; }
+.sc-topbar__spacer { flex: 1; }
+.sc-topbar__user { display: flex; align-items: center; gap: 8px; font-size: 14px; }
+.sc-topbar__menu { display: none; }
+.sc-avatar { width: 30px; height: 30px; border-radius: 50%; background: var(--sc-accent);
+  color: var(--sc-primaryText); display: grid; place-items: center; font-size: 12px; font-weight: 700; }
+
+/* ── Rooms ──────────────────────────────────────────────────── */
+.sc-rooms__head h1 { margin: 0 0 12px; }
+.sc-statrow { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 20px; }
+.sc-stat { background: var(--sc-surface); border: 1px solid var(--sc-border); border-radius: var(--sc-radius);
+  padding: 12px 18px; min-width: 96px; }
+.sc-stat__value { font-size: 22px; font-weight: 700; }
+.sc-stat__label { font-size: 12px; color: var(--sc-dim); }
+
+.sc-rooms__grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 14px; }
+.sc-room { background: var(--sc-surface); border: 1px solid var(--sc-border); border-left: 4px solid var(--sc-border);
+  border-radius: var(--sc-radius); padding: 14px; display: flex; flex-direction: column; gap: 8px; }
+.sc-room--available { border-left-color: var(--sc-ok); }
+.sc-room--occupied { border-left-color: var(--sc-primary); }
+.sc-room--reserved { border-left-color: var(--sc-warn); }
+.sc-room--maintenance { border-left-color: var(--sc-danger); }
+.sc-room__top { display: flex; justify-content: space-between; align-items: center; }
+.sc-room__number { font-size: 20px; font-weight: 700; }
+.sc-room__type { font-size: 13px; color: var(--sc-dim); }
+.sc-room__rate { font-size: 14px; font-weight: 600; }
+.sc-room__guest { font-size: 13px; }
+.sc-room__guest--empty { color: var(--sc-dim); }
+.sc-room__guest-name { font-weight: 600; }
+.sc-room__guest-meta { color: var(--sc-dim); font-size: 12px; }
+.sc-room__clean { margin-top: auto; text-transform: capitalize; font-size: 12.5px; }
+
+.sc-badge { font-size: 11px; padding: 2px 8px; border-radius: 20px; background: var(--sc-surfaceAlt); }
+.sc-badge--available { color: var(--sc-ok); }
+.sc-badge--occupied { color: var(--sc-primary); }
+.sc-badge--reserved { color: var(--sc-warn); }
+.sc-badge--maintenance { color: var(--sc-danger); }
+
+/* ── Upgrade gate / placeholder ─────────────────────────────── */
+.sc-upgrade, .sc-placeholder { max-width: 560px; margin: 40px auto; text-align: center;
+  background: var(--sc-surface); border: 1px solid var(--sc-border); border-radius: 16px; padding: 40px 32px; }
+.sc-upgrade__lock { font-size: 34px; }
+.sc-upgrade__title, .sc-placeholder__title { margin: 12px 0 8px; }
+.sc-upgrade__desc, .sc-placeholder__body { color: var(--sc-dim); line-height: 1.6; }
+.sc-upgrade__price { font-size: 26px; font-weight: 700; margin: 16px 0 20px; }
+.sc-upgrade__price span { font-size: 13px; font-weight: 400; color: var(--sc-dim); }
+.sc-placeholder { text-align: left; }
+.sc-placeholder__section { color: var(--sc-accent); font-size: 12px; text-transform: uppercase; letter-spacing: .05em; }
+
+.sc-loading, .sc-empty { padding: 40px; text-align: center; color: var(--sc-dim); }
+.sc-empty--error { color: var(--sc-danger); }
+
+/* ── Toasts ─────────────────────────────────────────────────── */
+.sc-toast-stack { position: fixed; bottom: 20px; right: 20px; display: flex; flex-direction: column; gap: 8px; z-index: 50; }
+.sc-toast { padding: 10px 16px; border-radius: 10px; color: #fff; font-size: 13px; box-shadow: 0 10px 30px -15px rgba(0,0,0,.5); }
+.sc-toast--success { background: var(--sc-ok); }
+.sc-toast--error { background: var(--sc-danger); }
+.sc-toast--info { background: var(--sc-accent); }
+
+/* ── Mobile ─────────────────────────────────────────────────── */
+@media (max-width: 820px) {
+  .sc-shell__nav { position: fixed; z-index: 40; height: 100%; transform: translateX(-100%); transition: transform .2s ease; }
+  .sc-shell--nav-open .sc-shell__nav { transform: translateX(0); }
+  .sc-shell--nav-open .sc-shell__scrim { display: block; position: fixed; inset: 0; background: rgba(0,0,0,.3); z-index: 39; }
+  .sc-topbar__menu { display: block; }
+  .sc-topbar__name { display: none; }
+}

--- a/sakthicloud/apps/web/src/styles.css
+++ b/sakthicloud/apps/web/src/styles.css
@@ -132,6 +132,48 @@ body { background: var(--sc-bg); }
 .sc-loading, .sc-empty { padding: 40px; text-align: center; color: var(--sc-dim); }
 .sc-empty--error { color: var(--sc-danger); }
 
+/* ── Bookings / tables ──────────────────────────────────────── */
+.sc-bookings__bar { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; margin-bottom: 18px; }
+.sc-filters { display: flex; gap: 6px; flex-wrap: wrap; }
+.sc-pill { border: 1px solid var(--sc-border); background: var(--sc-surface); color: var(--sc-text);
+  padding: 6px 14px; border-radius: 20px; font-size: 13px; cursor: pointer; }
+.sc-pill--active { background: var(--sc-primary); color: var(--sc-primaryText); border-color: transparent; }
+
+.sc-table__wrap { overflow-x: auto; border: 1px solid var(--sc-border); border-radius: var(--sc-radius); background: var(--sc-surface); }
+.sc-table { width: 100%; border-collapse: collapse; font-size: 14px; }
+.sc-table th, .sc-table td { padding: 11px 14px; text-align: left; border-bottom: 1px solid var(--sc-border); }
+.sc-table th { font-size: 12px; text-transform: uppercase; letter-spacing: .04em; color: var(--sc-dim); }
+.sc-table tr:last-child td { border-bottom: none; }
+.sc-table__total td { font-weight: 700; }
+.sc-num { text-align: right; font-variant-numeric: tabular-nums; }
+.sc-cell-strong { font-weight: 600; }
+.sc-cell-dim { color: var(--sc-dim); font-size: 12.5px; }
+.sc-badge--status-CHECKED_IN { color: var(--sc-primary); }
+.sc-badge--status-RESERVED { color: var(--sc-warn); }
+.sc-badge--status-CHECKED_OUT { color: var(--sc-dim); }
+
+/* ── Modal ──────────────────────────────────────────────────── */
+.sc-modal__backdrop { position: fixed; inset: 0; background: rgba(0,0,0,.4); display: grid; place-items: center; z-index: 60; padding: 20px; }
+.sc-modal { width: 100%; max-width: 460px; max-height: 90vh; overflow-y: auto; background: var(--sc-surface);
+  border: 1px solid var(--sc-border); border-radius: 16px; padding: 24px; }
+.sc-modal__title { margin: 0 0 18px; }
+.sc-modal__actions { display: flex; justify-content: flex-end; gap: 10px; margin-top: 8px; }
+.sc-grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.sc-field--inline { flex-direction: row; align-items: center; gap: 8px; }
+
+/* ── Folio ──────────────────────────────────────────────────── */
+.sc-folio { display: grid; grid-template-columns: 240px 1fr; gap: 18px; align-items: start; }
+.sc-folio__list { display: flex; flex-direction: column; gap: 8px; }
+.sc-folio__guest { text-align: left; padding: 10px 12px; border: 1px solid var(--sc-border); border-radius: 10px;
+  background: var(--sc-surface); cursor: pointer; }
+.sc-folio__guest--active { border-color: var(--sc-primary); box-shadow: inset 3px 0 0 var(--sc-primary); }
+.sc-folio__detail { background: var(--sc-surface); border: 1px solid var(--sc-border); border-radius: var(--sc-radius); padding: 20px; }
+.sc-folio__detail header { margin-bottom: 14px; }
+.sc-folio__detail h1 { margin: 0; }
+.sc-folio__post { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 16px; }
+.sc-folio__note { margin-top: 12px; }
+@media (max-width: 820px) { .sc-folio { grid-template-columns: 1fr; } }
+
 /* ── Toasts ─────────────────────────────────────────────────── */
 .sc-toast-stack { position: fixed; bottom: 20px; right: 20px; display: flex; flex-direction: column; gap: 8px; z-index: 50; }
 .sc-toast { padding: 10px 16px; border-radius: 10px; color: #fff; font-size: 13px; box-shadow: 0 10px 30px -15px rgba(0,0,0,.5); }

--- a/sakthicloud/apps/web/src/vite-env.d.ts
+++ b/sakthicloud/apps/web/src/vite-env.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL?: string;
+}
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/sakthicloud/apps/web/tsconfig.json
+++ b/sakthicloud/apps/web/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "types": ["vite/client", "node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@sakthicloud/shared": ["../../packages/shared/src/index.ts"]
+    }
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/sakthicloud/apps/web/vite.config.ts
+++ b/sakthicloud/apps/web/vite.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { fileURLToPath, URL } from "node:url";
+
+// The API backend the SPA talks to. Defaults to the local Fastify dev server;
+// in production it is served same-origin behind /api/v1, so VITE_API_URL="".
+const API_TARGET = process.env.VITE_API_PROXY || "http://localhost:3001";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+      "@sakthicloud/shared": fileURLToPath(
+        new URL("../../packages/shared/src/index.ts", import.meta.url),
+      ),
+    },
+  },
+  server: {
+    port: 5173,
+    proxy: {
+      "/api": { target: API_TARGET, changeOrigin: true },
+    },
+  },
+  build: {
+    target: "es2022",
+    sourcemap: true,
+  },
+});

--- a/sakthicloud/package.json
+++ b/sakthicloud/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "sakthicloud",
+  "private": true,
+  "version": "0.1.0",
+  "description": "SakthiCloud — multi-tenant hotel PMS SaaS (production monorepo)",
+  "packageManager": "pnpm@10.33.0",
+  "scripts": {
+    "dev": "turbo run dev",
+    "build": "turbo run build",
+    "typecheck": "turbo run typecheck"
+  },
+  "devDependencies": {
+    "turbo": "^2.3.3",
+    "typescript": "^5.6.3"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
+  }
+}

--- a/sakthicloud/packages/shared/package.json
+++ b/sakthicloud/packages/shared/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@sakthicloud/shared",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./schemas": "./src/schemas/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.3"
+  }
+}

--- a/sakthicloud/packages/shared/src/entitlements.ts
+++ b/sakthicloud/packages/shared/src/entitlements.ts
@@ -1,0 +1,74 @@
+// ═══════════════════════════════════════════════════════════
+// SaaS ENTITLEMENTS — the single source of truth, shared by web + api.
+// Core = Front Desk + Housekeeping (a complete, compliant PMS on its own).
+// Everything else is a per-property, per-month add-on.
+// Ported verbatim from the prototype's ADDON_CATALOG so the contract
+// never drifts between frontend gating and backend requireEntitlement().
+// Prices are INDICATIVE placeholders — set real pricing before launch.
+// ═══════════════════════════════════════════════════════════
+
+export interface AddonDef {
+  id: string;
+  label: string;
+  desc: string;
+  modules: string[];
+  price: number;
+  soon?: boolean;
+}
+
+export interface RoomBand {
+  id: string;
+  label: string;
+  price: number;
+}
+
+export const ADDON_CATALOG: AddonDef[] = [
+  { id: "revenue", label: "Revenue & Direct Bookings", desc: "Dynamic rate plans, seasons, promos and meal plans, plus your own commission-free booking website with Razorpay.", modules: ["bookingengine", "rateplans"], price: 1299 },
+  { id: "accounting", label: "Accounting & Finance", desc: "Full books — P&L, departmental GOP, GST returns, TDS, RCM, depreciation, balance sheet and owner statements.", modules: ["finance"], price: 1499 },
+  { id: "crm", label: "Guest CRM & Marketing", desc: "Guest segmentation, one-tap WhatsApp templates and campaigns, and a loyalty programme.", modules: ["guestcrm", "loyalty"], price: 999 },
+  { id: "staff", label: "Staff, Payroll & Performance", desc: "Roster and payroll, plus deadline- and rating-based employee performance across every department.", modules: ["staff", "performance"], price: 999 },
+  { id: "assets", label: "Assets & Inventory", desc: "Asset lifecycle and depreciation, stock control with amenity formats, and vendor management.", modules: ["assets", "inventory", "vendors"], price: 899 },
+  { id: "selfservice", label: "Guest Self-Service", desc: "Reception kiosk, web check-in, and in-room Wi-Fi / TV ordering.", modules: ["kiosk", "wifi", "tv"], price: 1199 },
+  { id: "ai", label: "Specter AI", desc: "An AI co-pilot across your whole property. Usage-metered on top of any plan.", modules: ["copilot"], price: 799 },
+  { id: "banquet", label: "Banquet & Events", desc: "Configurable halls billed hourly or daily, event orders (BEO), advances and setup tasks — all through the GST folio.", modules: ["banquet"], price: 1199 },
+  { id: "restaurant", label: "Restaurant & Café POS", desc: "Table-service POS with a menu, KOT to the kitchen, running table bills, and pay-at-table or charge-to-room settlement at 5% F&B GST.", modules: ["restaurant", "kitchen", "kitcheninv"], price: 1299 },
+  { id: "spa", label: "Spa & Wellness", desc: "Appointment booking for spa and salon services with therapist scheduling, and pay-at-desk or charge-to-room settlement at 18% GST.", modules: ["spa"], price: 999 },
+  { id: "channel", label: "Channel Manager", desc: "Two-way inventory and rate sync with OTAs (Booking.com, MakeMyTrip, Agoda).", modules: ["channels"], price: 1999, soon: true },
+];
+
+export const ROOM_BANDS: RoomBand[] = [
+  { id: "1-20", label: "Up to 20 rooms", price: 1999 },
+  { id: "21-50", label: "21–50 rooms", price: 3499 },
+  { id: "51-100", label: "51–100 rooms", price: 5999 },
+  { id: "100+", label: "100+ rooms", price: 8999 },
+];
+
+// module -> add-on id. Anything not present here is Core (always allowed).
+export const MODULE_ADDON: Record<string, string> = ADDON_CATALOG.reduce(
+  (acc, addon) => {
+    for (const m of addon.modules) acc[m] = addon.id;
+    return acc;
+  },
+  {} as Record<string, string>,
+);
+
+export function moduleAddonId(moduleId: string): string | null {
+  return MODULE_ADDON[moduleId] ?? null;
+}
+
+export function isCoreModule(moduleId: string): boolean {
+  return !MODULE_ADDON[moduleId];
+}
+
+export interface Subscription {
+  plan: string;
+  addons: string[];
+  roomBand: string;
+}
+
+/** A module is locked when it belongs to an add-on the tenant hasn't purchased. */
+export function isModuleLocked(moduleId: string, subscription: Subscription | null | undefined): boolean {
+  const addon = MODULE_ADDON[moduleId];
+  if (!addon) return false; // Core module — always available
+  return !(subscription?.addons ?? []).includes(addon);
+}

--- a/sakthicloud/packages/shared/src/index.ts
+++ b/sakthicloud/packages/shared/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./entitlements";
+export * from "./nav";
+export * from "./roles";
+export * from "./schemas/index";

--- a/sakthicloud/packages/shared/src/nav.ts
+++ b/sakthicloud/packages/shared/src/nav.ts
@@ -1,0 +1,77 @@
+// Navigation contract — the 32 modules grouped into 9 sections, ported
+// verbatim from the prototype's ALL_NAV. Sections render in this order;
+// a section header appears wherever `sec` changes down the list.
+
+export interface NavItem {
+  id: string;
+  label: string;
+  icon: string;
+  sec: SectionName;
+}
+
+export type SectionName =
+  | "Overview"
+  | "Front Office"
+  | "Food & Beverage"
+  | "Spa & Wellness"
+  | "Operations"
+  | "Finance"
+  | "People & Guests"
+  | "Distribution & In-Room"
+  | "Setup";
+
+export const SECTION_ORDER: SectionName[] = [
+  "Overview",
+  "Front Office",
+  "Food & Beverage",
+  "Spa & Wellness",
+  "Operations",
+  "Finance",
+  "People & Guests",
+  "Distribution & In-Room",
+  "Setup",
+];
+
+export const ALL_NAV: NavItem[] = [
+  { id: "dashboard", label: "Dashboard", icon: "grid", sec: "Overview" },
+  { id: "copilot", label: "Specter", icon: "sparkles", sec: "Overview" },
+
+  { id: "rooms", label: "Rooms", icon: "bed", sec: "Front Office" },
+  { id: "bookings", label: "Bookings", icon: "calendar-check", sec: "Front Office" },
+  { id: "folio", label: "Folios", icon: "receipt", sec: "Front Office" },
+  { id: "tapechart", label: "Calendar", icon: "calendar", sec: "Front Office" },
+  { id: "nightaudit", label: "Night Audit", icon: "moon", sec: "Front Office" },
+  { id: "bookingengine", label: "Booking Engine", icon: "globe", sec: "Front Office" },
+  { id: "rateplans", label: "Rate Plans", icon: "tag", sec: "Front Office" },
+  { id: "kiosk", label: "Reception Kiosk", icon: "tablet", sec: "Front Office" },
+
+  { id: "restaurant", label: "Restaurant", icon: "utensils", sec: "Food & Beverage" },
+  { id: "kitchen", label: "Kitchen (KDS)", icon: "bell", sec: "Food & Beverage" },
+  { id: "kitcheninv", label: "Kitchen Inventory", icon: "boxes", sec: "Food & Beverage" },
+  { id: "banquet", label: "Banquet & Events", icon: "party", sec: "Food & Beverage" },
+
+  { id: "spa", label: "Spa & Wellness", icon: "flower", sec: "Spa & Wellness" },
+
+  { id: "housekeeping", label: "Housekeeping", icon: "broom", sec: "Operations" },
+  { id: "assets", label: "Assets", icon: "wrench", sec: "Operations" },
+  { id: "inventory", label: "Inventory", icon: "boxes", sec: "Operations" },
+  { id: "vendors", label: "Vendors", icon: "truck", sec: "Operations" },
+
+  { id: "finance", label: "Finance & Accounts", icon: "book", sec: "Finance" },
+  { id: "compliance", label: "Compliance", icon: "shield", sec: "Finance" },
+  { id: "reports", label: "Reports", icon: "chart", sec: "Finance" },
+
+  { id: "staff", label: "Staff & Payroll", icon: "users", sec: "People & Guests" },
+  { id: "performance", label: "Performance", icon: "chart", sec: "People & Guests" },
+  { id: "guestcrm", label: "Guests", icon: "heart", sec: "People & Guests" },
+  { id: "loyalty", label: "Loyalty", icon: "star", sec: "People & Guests" },
+
+  { id: "channels", label: "Channel Manager", icon: "share", sec: "Distribution & In-Room" },
+  { id: "wifi", label: "Wi-Fi", icon: "wifi", sec: "Distribution & In-Room" },
+  { id: "tv", label: "In-Room TVs", icon: "tv", sec: "Distribution & In-Room" },
+
+  { id: "properties", label: "Properties", icon: "building", sec: "Setup" },
+  { id: "users", label: "User Management", icon: "user-cog", sec: "Setup" },
+  { id: "branding", label: "Branding", icon: "palette", sec: "Setup" },
+  { id: "subscription", label: "Plan & Billing", icon: "credit-card", sec: "Setup" },
+];

--- a/sakthicloud/packages/shared/src/roles.ts
+++ b/sakthicloud/packages/shared/src/roles.ts
@@ -1,0 +1,42 @@
+// Role → default module access, plus the per-user override resolution.
+// Mirrors the prototype's ROLES map + effectiveModules(). Owners always get
+// everything; a user's explicit `allowedModules` (the owner override stored in
+// users.allowed_modules) wins over the role default when present.
+//
+// NOTE: the per-role lists below are the faithful shape; port the exact arrays
+// from the prototype's ROLES object when migrating the User Management module.
+
+import { ALL_NAV } from "./nav";
+import type { AuthUser } from "./schemas/auth";
+
+const ALL_MODULE_IDS = ALL_NAV.map((n) => n.id);
+
+// Core front-desk set every guest-facing role needs.
+const FRONT_DESK = [
+  "dashboard", "rooms", "bookings", "folio", "tapechart", "nightaudit",
+  "housekeeping", "compliance", "reports", "guestcrm",
+];
+
+export const ROLES: Record<string, { label: string; modules: string[] }> = {
+  OWNER: { label: "Owner", modules: ALL_MODULE_IDS },
+  MANAGER: { label: "Manager", modules: ALL_MODULE_IDS },
+  FRONT_DESK_SUPERVISOR: {
+    label: "Front Desk Supervisor",
+    modules: [...FRONT_DESK, "bookingengine", "rateplans", "restaurant", "banquet", "spa", "kiosk"],
+  },
+  RECEPTIONIST: { label: "Receptionist", modules: FRONT_DESK },
+  ACCOUNTANT: {
+    label: "Accountant",
+    modules: ["dashboard", "finance", "reports", "compliance", "assets", "inventory", "vendors", "folio"],
+  },
+  HOUSEKEEPING: { label: "Housekeeping", modules: ["dashboard", "rooms", "housekeeping"] },
+  NIGHT_AUDITOR: { label: "Night Auditor", modules: ["dashboard", "rooms", "bookings", "folio", "nightaudit", "reports"] },
+  STAFF: { label: "Staff", modules: ["dashboard"] },
+};
+
+/** Effective module access for a user (before entitlement locking is applied). */
+export function effectiveModulesFor(user: Pick<AuthUser, "role" | "allowedModules">): string[] {
+  if (user.role === "OWNER") return ROLES.OWNER.modules;
+  if (Array.isArray(user.allowedModules)) return user.allowedModules;
+  return ROLES[user.role]?.modules ?? ["dashboard"];
+}

--- a/sakthicloud/packages/shared/src/schemas/auth.ts
+++ b/sakthicloud/packages/shared/src/schemas/auth.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+
+// Roles as stored by the backend (upper-case) — normalised to lower-case in the app.
+export const Role = z.enum([
+  "OWNER",
+  "MANAGER",
+  "FRONT_DESK_SUPERVISOR",
+  "RECEPTIONIST",
+  "ACCOUNTANT",
+  "HOUSEKEEPING",
+  "NIGHT_AUDITOR",
+  "STAFF",
+]);
+export type Role = z.infer<typeof Role>;
+
+export const LoginRequest = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+});
+export type LoginRequest = z.infer<typeof LoginRequest>;
+
+export const AuthUser = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string().email(),
+  role: Role,
+  phone: z.string().optional().default(""),
+  allowedModules: z.array(z.string()).nullable().optional(),
+});
+export type AuthUser = z.infer<typeof AuthUser>;
+
+export const PropertyRef = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+export type PropertyRef = z.infer<typeof PropertyRef>;
+
+export const Tenant = z.object({
+  id: z.string(),
+  name: z.string(),
+  addons: z.array(z.string()).default([]),
+  roomBand: z.string().optional(),
+  plan: z.string().optional(),
+});
+export type Tenant = z.infer<typeof Tenant>;
+
+export const LoginResponse = z.object({
+  accessToken: z.string(),
+  refreshToken: z.string(),
+  user: AuthUser,
+  tenant: Tenant,
+  properties: z.array(PropertyRef).default([]),
+});
+export type LoginResponse = z.infer<typeof LoginResponse>;
+
+export const RefreshResponse = z.object({
+  accessToken: z.string(),
+  refreshToken: z.string(),
+});
+export type RefreshResponse = z.infer<typeof RefreshResponse>;

--- a/sakthicloud/packages/shared/src/schemas/booking.ts
+++ b/sakthicloud/packages/shared/src/schemas/booking.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+export const Guest = z.object({
+  name: z.string(),
+  phone: z.string(),
+  email: z.string().optional().default(""),
+  idType: z.string().optional().default("Aadhaar"),
+  idNumber: z.string().optional().default(""),
+  nationality: z.string().optional().default("Indian"),
+  adults: z.number().int().positive().default(1),
+  children: z.number().int().nonnegative().default(0),
+  checkIn: z.string().optional(),
+  checkOut: z.string().optional(),
+  advancePayment: z.number().nonnegative().default(0),
+  paymentMode: z.string().optional().default("UPI"),
+  purpose: z.string().optional().default("Business"),
+  bookingId: z.string().optional(),
+});
+export type Guest = z.infer<typeof Guest>;
+
+export const CheckInRequest = z.object({
+  roomId: z.string(),
+  guest: Guest,
+});
+export type CheckInRequest = z.infer<typeof CheckInRequest>;

--- a/sakthicloud/packages/shared/src/schemas/booking.ts
+++ b/sakthicloud/packages/shared/src/schemas/booking.ts
@@ -1,11 +1,16 @@
 import { z } from "zod";
 
+export const BookingStatus = z.enum(["RESERVED", "CHECKED_IN", "CHECKED_OUT"]);
+export type BookingStatus = z.infer<typeof BookingStatus>;
+
 export const Guest = z.object({
   name: z.string(),
   phone: z.string(),
   email: z.string().optional().default(""),
+  company: z.string().optional(),
   idType: z.string().optional().default("Aadhaar"),
   idNumber: z.string().optional().default(""),
+  idImage: z.string().optional(),
   nationality: z.string().optional().default("Indian"),
   adults: z.number().int().positive().default(1),
   children: z.number().int().nonnegative().default(0),
@@ -18,8 +23,88 @@ export const Guest = z.object({
 });
 export type Guest = z.infer<typeof Guest>;
 
+// ── Check-in ── (matches backend checkInSchema exactly)
 export const CheckInRequest = z.object({
   roomId: z.string(),
-  guest: Guest,
+  guest: z.object({
+    name: z.string().min(2),
+    phone: z.string().min(10),
+    email: z.string().email().optional(),
+    company: z.string().optional(),
+    idType: z.string().default("Aadhaar"),
+    idNumber: z.string().min(4),
+    idImage: z.string().optional(),
+    nationality: z.string().default("Indian"),
+  }),
+  checkIn: z.string(),
+  checkOut: z.string(),
+  billingAC: z.boolean().default(true),
+  adults: z.number().int().min(1).default(1),
+  children: z.number().int().min(0).default(0),
+  advancePayment: z.number().min(0).default(0),
+  paymentMode: z.string().default("UPI"),
+  bookingSource: z.string().default("Walk-in"),
+  purpose: z.string().optional(),
+  notes: z.string().optional(),
 });
 export type CheckInRequest = z.infer<typeof CheckInRequest>;
+
+// ── Check-out ── (matches backend checkOutSchema)
+export const CheckOutRequest = z.object({
+  extras: z
+    .array(z.object({ description: z.string(), amount: z.number().positive() }))
+    .default([]),
+  discount: z.number().min(0).default(0),
+  paymentMode: z.string().default("UPI"),
+  sendWhatsApp: z.boolean().default(false),
+  sendEmail: z.boolean().default(false),
+});
+export type CheckOutRequest = z.infer<typeof CheckOutRequest>;
+
+// ── Booking (app-facing, flattened from the list response) ──
+export const Booking = z.object({
+  id: z.string(),
+  status: BookingStatus,
+  guestName: z.string(),
+  guestPhone: z.string(),
+  roomId: z.string().nullable(),
+  roomNumber: z.string(),
+  roomType: z.string(),
+  checkIn: z.string(),
+  checkOut: z.string(),
+  nights: z.number().int().nonnegative(),
+  adults: z.number().int().nonnegative(),
+  children: z.number().int().nonnegative(),
+  grandTotal: z.number().nonnegative(),
+  advancePayment: z.number().nonnegative(),
+  balanceDue: z.number(),
+  bookingSource: z.string(),
+});
+export type Booking = z.infer<typeof Booking>;
+
+// Raw row from GET /properties/:id/bookings (subset relied upon).
+export const BookingApiRow = z.object({
+  id: z.string(),
+  status: z.string(),
+  checkIn: z.string().nullish(),
+  checkOut: z.string().nullish(),
+  adults: z.number().nullish(),
+  children: z.number().nullish(),
+  grandTotal: z.union([z.string(), z.number()]).nullish(),
+  advancePayment: z.union([z.string(), z.number()]).nullish(),
+  balanceDue: z.union([z.string(), z.number()]).nullish(),
+  bookingSource: z.string().nullish(),
+  guest: z.object({ name: z.string().nullish(), phone: z.string().nullish() }).nullish(),
+  room: z
+    .object({ number: z.string().nullish(), roomType: z.object({ name: z.string().nullish() }).nullish() })
+    .nullish(),
+});
+export type BookingApiRow = z.infer<typeof BookingApiRow>;
+
+export const BookingsListResponse = z.object({
+  bookings: z.array(BookingApiRow),
+  total: z.number(),
+  page: z.number(),
+  pages: z.number(),
+});
+export type BookingsListResponse = z.infer<typeof BookingsListResponse>;

--- a/sakthicloud/packages/shared/src/schemas/folio.ts
+++ b/sakthicloud/packages/shared/src/schemas/folio.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+// Folio contract for the persistence backlog (folio_line, folio_payment).
+// The prototype held these in React state; defining the schema here is step 1
+// of migrating the module. The Folio page can already render a running bill
+// derived from the booking (room charge + GST); incidental lines + payments
+// persist once the backend tables land. Payments post to the ledger today.
+
+export const FOLIO_CATEGORIES = [
+  "Room Charge",
+  "Food & Beverage",
+  "Minibar",
+  "Laundry",
+  "Spa & Wellness",
+  "Telephone / Internet",
+  "Airport Transfer",
+  "Extra Bed",
+  "Room Service",
+  "Restaurant / F&B",
+  "Damage / Penalty",
+  "Misc",
+] as const;
+
+export const FolioTarget = z.enum(["guest", "company"]);
+export type FolioTarget = z.infer<typeof FolioTarget>;
+
+export const FolioLine = z.object({
+  id: z.string(),
+  category: z.enum(FOLIO_CATEGORIES),
+  description: z.string().default(""),
+  amount: z.number().nonnegative(),
+  gstRate: z.number().nonnegative().default(12),
+  target: FolioTarget.default("guest"),
+  postedAt: z.string(),
+});
+export type FolioLine = z.infer<typeof FolioLine>;
+
+export const FolioPayment = z.object({
+  id: z.string(),
+  amount: z.number().nonnegative(),
+  mode: z.string(),
+  target: FolioTarget.default("guest"),
+  paidAt: z.string(),
+});
+export type FolioPayment = z.infer<typeof FolioPayment>;
+
+export const PostChargeRequest = FolioLine.omit({ id: true, postedAt: true });
+export type PostChargeRequest = z.infer<typeof PostChargeRequest>;
+
+export const RecordPaymentRequest = FolioPayment.omit({ id: true, paidAt: true });
+export type RecordPaymentRequest = z.infer<typeof RecordPaymentRequest>;

--- a/sakthicloud/packages/shared/src/schemas/index.ts
+++ b/sakthicloud/packages/shared/src/schemas/index.ts
@@ -1,0 +1,3 @@
+export * from "./auth";
+export * from "./room";
+export * from "./booking";

--- a/sakthicloud/packages/shared/src/schemas/index.ts
+++ b/sakthicloud/packages/shared/src/schemas/index.ts
@@ -1,3 +1,4 @@
 export * from "./auth";
 export * from "./room";
 export * from "./booking";
+export * from "./folio";

--- a/sakthicloud/packages/shared/src/schemas/room.ts
+++ b/sakthicloud/packages/shared/src/schemas/room.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import { Guest } from "./booking";
+
+export const RoomStatus = z.enum(["available", "occupied", "reserved", "maintenance"]);
+export type RoomStatus = z.infer<typeof RoomStatus>;
+
+export const CleanStatus = z.enum(["clean", "dirty", "inspected"]);
+export type CleanStatus = z.infer<typeof CleanStatus>;
+
+// The app-facing Room shape (post-mapRoom in the prototype). The API returns
+// a nested Prisma shape (roomType, bookings[]) which the fetcher flattens to this.
+export const Room = z.object({
+  id: z.string(),
+  number: z.string(),
+  type: z.string(),
+  propertyId: z.string(),
+  floor: z.string().optional().default(""),
+  rate: z.number().nonnegative(),
+  rateAC: z.number().nonnegative().default(0),
+  rateNonAC: z.number().nonnegative().default(0),
+  gstRate: z.number().default(12),
+  status: RoomStatus,
+  cleanStatus: CleanStatus,
+  guest: Guest.nullable().default(null),
+  amenities: z.array(z.string()).default([]),
+  notes: z.string().optional().default(""),
+});
+export type Room = z.infer<typeof Room>;
+
+// Raw API row (subset we rely on) — used to type the flattening step.
+export const RoomApiRow = z.object({
+  id: z.string(),
+  number: z.string(),
+  propertyId: z.string(),
+  floor: z.string().nullish(),
+  status: z.string().nullish(),
+  cleanStatus: z.string().nullish(),
+  currentRate: z.union([z.string(), z.number()]).nullish(),
+  notes: z.string().nullish(),
+  roomType: z
+    .object({
+      name: z.string().nullish(),
+      rateAC: z.union([z.string(), z.number()]).nullish(),
+      rateNonAC: z.union([z.string(), z.number()]).nullish(),
+      gstRate: z.union([z.string(), z.number()]).nullish(),
+      amenities: z.array(z.string()).nullish(),
+    })
+    .nullish(),
+  bookings: z.array(z.any()).nullish(),
+});
+export type RoomApiRow = z.infer<typeof RoomApiRow>;
+
+export const UpdateRoomRequest = Room.partial().omit({ id: true, propertyId: true, guest: true });
+export type UpdateRoomRequest = z.infer<typeof UpdateRoomRequest>;

--- a/sakthicloud/packages/shared/tsconfig.json
+++ b/sakthicloud/packages/shared/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/sakthicloud/pnpm-lock.yaml
+++ b/sakthicloud/pnpm-lock.yaml
@@ -1,0 +1,1242 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      turbo:
+        specifier: ^2.3.3
+        version: 2.10.3
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  apps/web:
+    dependencies:
+      '@sakthicloud/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      '@tanstack/react-query':
+        specifier: ^5.59.16
+        version: 5.101.2(react@18.3.1)
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+      react-router-dom:
+        specifier: ^6.28.0
+        version: 6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.20.0
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.31
+      '@types/react-dom':
+        specifier: ^18.3.1
+        version: 18.3.7(@types/react@18.3.31)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.3
+        version: 4.7.0(vite@5.4.21(@types/node@22.20.0))
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+      vite:
+        specifier: ^5.4.10
+        version: 5.4.21(@types/node@22.20.0)
+
+  packages/shared:
+    dependencies:
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+packages:
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@remix-run/router@1.23.3':
+    resolution: {integrity: sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==}
+    engines: {node: '>=14.0.0'}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@tanstack/query-core@5.101.2':
+    resolution: {integrity: sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==}
+
+  '@tanstack/react-query@5.101.2':
+    resolution: {integrity: sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==}
+    peerDependencies:
+      react: ^18 || ^19
+
+  '@turbo/darwin-64@2.10.3':
+    resolution: {integrity: sha512-guuiO2kKc7yUQFU2jhWyM/BrYGD/brqb0+JvJIXTQ/QI1NlWfHZ1id50kkkOWqxmBiDc8DgW2orfY85pQIc7gw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.10.3':
+    resolution: {integrity: sha512-UglEDl/r1/h5Vw6oS6cEE29Jugz2sDLxHCSupNznKatj1fDMRXFqYKFcbvm8RTFhtYPI45NxkrPNo9BqNychBg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.10.3':
+    resolution: {integrity: sha512-KuQxaPWD7OBmwEZqO0sgijwcuXR5eMWbo7BEt2m1D2Q3RylJDj7WMcJ0Btv2VJA0QC+khzAaTAm1yWowJ0CWAw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@turbo/linux-arm64@2.10.3':
+    resolution: {integrity: sha512-DPkIKQ+6p0sho3Cx/e/A3F+AKgXQJA+z//cHsTcyyM1YWRGSYA0UTP8NUpb4iS2tVBSniGwmjRUr73hpq8kcDg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/windows-64@2.10.3':
+    resolution: {integrity: sha512-8NvFAze9D4PsosZAnK3aGqHz2vLzREz9lNIxLgfE0jRchq2sZQE190cwFm7WX17yg3ftPvwCvWH3rhLbG1UHCQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.10.3':
+    resolution: {integrity: sha512-AqjqV5cHbFa0YRaQ+Dyw6lSm6as4h/Uf8LcZ7VN8i+Odr23ShFD5SUvVAR1d3rZqibFVs9c0VdtXdfQfkdcs3A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@22.20.0':
+    resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
+
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
+  '@types/react@18.3.31':
+    resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  baseline-browser-mapping@2.10.42:
+    resolution: {integrity: sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  browserslist@4.28.5:
+    resolution: {integrity: sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  caniuse-lite@1.0.30001802:
+    resolution: {integrity: sha512-vmv8ub2xwTNmljSKf82mtCk5JH7hC+YgzLj3P5zotvA0tPQ9016tdNNOG8WRca1IxOnhSsivB+J0z5FeE5LOUw==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  electron-to-chromium@1.5.387:
+    resolution: {integrity: sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-releases@2.0.50:
+    resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
+    engines: {node: '>=18'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react-router-dom@6.30.4:
+    resolution: {integrity: sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  react-router@6.30.4:
+    resolution: {integrity: sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  turbo@2.10.3:
+    resolution: {integrity: sha512-uZIqzfgtWbyqu1Tqwdd0giRnPGgL0ejbcdF8eZLJhtTTVSrOgArZGzYeXTD6XNcc7ANgdhqex11Y9bHBeyiQLQ==}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.5
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@remix-run/router@1.23.3': {}
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
+
+  '@tanstack/query-core@5.101.2': {}
+
+  '@tanstack/react-query@5.101.2(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.101.2
+      react: 18.3.1
+
+  '@turbo/darwin-64@2.10.3':
+    optional: true
+
+  '@turbo/darwin-arm64@2.10.3':
+    optional: true
+
+  '@turbo/linux-64@2.10.3':
+    optional: true
+
+  '@turbo/linux-arm64@2.10.3':
+    optional: true
+
+  '@turbo/windows-64@2.10.3':
+    optional: true
+
+  '@turbo/windows-arm64@2.10.3':
+    optional: true
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@22.20.0':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@18.3.7(@types/react@18.3.31)':
+    dependencies:
+      '@types/react': 18.3.31
+
+  '@types/react@18.3.31':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@22.20.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 5.4.21(@types/node@22.20.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  baseline-browser-mapping@2.10.42: {}
+
+  browserslist@4.28.5:
+    dependencies:
+      baseline-browser-mapping: 2.10.42
+      caniuse-lite: 1.0.30001802
+      electron-to-chromium: 1.5.387
+      node-releases: 2.0.50
+      update-browserslist-db: 1.2.3(browserslist@4.28.5)
+
+  caniuse-lite@1.0.30001802: {}
+
+  convert-source-map@2.0.0: {}
+
+  csstype@3.2.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  electron-to-chromium@1.5.387: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  escalade@3.2.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  js-tokens@4.0.0: {}
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.15: {}
+
+  node-releases@2.0.50: {}
+
+  picocolors@1.1.1: {}
+
+  postcss@8.5.16:
+    dependencies:
+      nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react-refresh@0.17.0: {}
+
+  react-router-dom@6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@remix-run/router': 1.23.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-router: 6.30.4(react@18.3.1)
+
+  react-router@6.30.4(react@18.3.1):
+    dependencies:
+      '@remix-run/router': 1.23.3
+      react: 18.3.1
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
+  rollup@4.62.2:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
+      fsevents: 2.3.3
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
+  semver@6.3.1: {}
+
+  source-map-js@1.2.1: {}
+
+  turbo@2.10.3:
+    optionalDependencies:
+      '@turbo/darwin-64': 2.10.3
+      '@turbo/darwin-arm64': 2.10.3
+      '@turbo/linux-64': 2.10.3
+      '@turbo/linux-arm64': 2.10.3
+      '@turbo/windows-64': 2.10.3
+      '@turbo/windows-arm64': 2.10.3
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.5):
+    dependencies:
+      browserslist: 4.28.5
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  vite@5.4.21(@types/node@22.20.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.16
+      rollup: 4.62.2
+    optionalDependencies:
+      '@types/node': 22.20.0
+      fsevents: 2.3.3
+
+  yallist@3.1.1: {}
+
+  zod@3.25.76: {}

--- a/sakthicloud/pnpm-workspace.yaml
+++ b/sakthicloud/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "apps/*"
+  - "packages/*"

--- a/sakthicloud/tsconfig.base.json
+++ b/sakthicloud/tsconfig.base.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true
+  }
+}

--- a/sakthicloud/turbo.json
+++ b/sakthicloud/turbo.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "typecheck": {
+      "dependsOn": ["^build"]
+    },
+    "lint": {},
+    "dev": {
+      "cache": false,
+      "persistent": true
+    }
+  }
+}


### PR DESCRIPTION
Transforms the single-file, Babel-in-browser prototype into a bundled,
code-split, API-backed SPA built to serve thousands of subscriber hotels,
following docs/PRODUCTION-ARCHITECTURE.md.

Monorepo (pnpm + Turborepo) under sakthicloud/:
- packages/shared: the web<->api contract — Zod schemas (auth/room/booking),
  entitlements (ADDON_CATALOG/MODULE_ADDON/ROOM_BANDS) and roles, ported
  verbatim from the prototype so gating never drifts from the backend.
- apps/web: Vite + React + TS SPA
  - lib/api-client: typed fetch with Bearer auth + transparent 401 refresh
  - lib/query-client, lib/ws (per-tenant live channel), lib/theme (CSS vars)
  - app/: providers, code-split + entitlement-gated router, auth context,
    shell (section sidebar for all 32 modules, tenant/property topbar)
  - features/front-desk/rooms: the reference vertical slice proving the
    useState -> TanStack Query persistence pattern (optimistic updates,
    WS invalidation), wired to the real /properties/:id/rooms endpoints.

Verified: shared typechecks; web typechecks and vite build succeeds with
per-module code-splitting (RoomsPage emits its own chunk); built app serves.

Every remaining module repeats the Rooms slice:
model -> schema -> route -> hook -> component -> WebSocket.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R542KssVRJTfXNVFYpJGxK